### PR TITLE
Set PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT to fix CDN timeout failures in .NET Aspire scenario

### DIFF
--- a/scenarios/macos/mac_net_aspire/mac_net_aspire.py
+++ b/scenarios/macos/mac_net_aspire/mac_net_aspire.py
@@ -14,7 +14,7 @@ import time
 class MacNetAspire(core.app_scenario.Scenario):
 
     module = __module__.split('.')[-1]
-    prep_version = "6"
+    prep_version = "7"
     resources = module + "_resources"
 
 

--- a/scenarios/macos/mac_net_aspire/mac_net_aspire_resources/mac_net_aspire_prep.sh
+++ b/scenarios/macos/mac_net_aspire/mac_net_aspire_resources/mac_net_aspire_prep.sh
@@ -157,6 +157,10 @@ log "-- Setting Python version"
 pyenv global 3.12.10
 check_status "Setting Python global version"
 
+# Increase Playwright browser download timeout (default is too short for slow CDN)
+export PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT=300000
+log "-- Set PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT=300000 (5 minutes)"
+
 # Verify Python version
 PYTHON_VERSION=$(python --version 2>&1 | awk '{print $2}')
 if [ "$PYTHON_VERSION" != "3.12.10" ]; then

--- a/scenarios/macos/mac_net_aspire/mac_net_aspire_resources/mac_net_aspire_run.sh
+++ b/scenarios/macos/mac_net_aspire/mac_net_aspire_resources/mac_net_aspire_run.sh
@@ -125,6 +125,10 @@ if [ ! -f "build.sh" ]; then
 fi
 log "✓ build.sh found"
 
+# Increase Playwright browser download timeout (default is too short for slow CDN)
+export PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT=300000
+log "-- Set PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT=300000 (5 minutes)"
+
 # ============================================================================
 # Clean phase (not timed)
 # ============================================================================

--- a/scenarios/windows/net_aspire/net_aspire.py
+++ b/scenarios/windows/net_aspire/net_aspire.py
@@ -14,7 +14,7 @@ from datetime import datetime
 class NetAspire(core.app_scenario.Scenario):
 
     module = __module__.split('.')[-1]
-    prep_version = "6"
+    prep_version = "7"
     resources = module + "_resources"
 
 

--- a/scenarios/windows/net_aspire/net_aspire_resources/net_aspire_prep.ps1
+++ b/scenarios/windows/net_aspire/net_aspire_resources/net_aspire_prep.ps1
@@ -208,6 +208,12 @@ $env:DOTNET_INSTALL_DIR = "C:\Program Files\dotnet"
 "-- Set DOTNET_INSTALL_DIR=$($env:DOTNET_INSTALL_DIR) to use system SDK" | log
 
 # -------------------------------------------------------------------
+# Increase Playwright browser download timeout (default is too short for slow CDN)
+# -------------------------------------------------------------------
+$env:PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT = "300000"
+"-- Set PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT=300000 (5 minutes)" | log
+
+# -------------------------------------------------------------------
 # Initial restore (so run iterations only need build)
 # -------------------------------------------------------------------
 "-- Running initial dotnet restore" | log

--- a/scenarios/windows/net_aspire/net_aspire_resources/net_aspire_run.ps1
+++ b/scenarios/windows/net_aspire/net_aspire_resources/net_aspire_run.ps1
@@ -130,6 +130,10 @@ $env:DOTNET_INSTALL_DIR = "C:\Program Files\dotnet"
 "-- All installed SDKs:" | log
 dotnet --list-sdks 2>&1 | ForEach-Object { "   $_" | log }
 
+# Increase Playwright browser download timeout (default is too short for slow CDN)
+$env:PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT = "300000"
+"-- Set PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT=300000 (5 minutes)" | log
+
 # ============================================================================
 # Clean phase (not timed)
 # ============================================================================


### PR DESCRIPTION
Playwright browser downloads were failing due to upstream CDN slowness and the default connection timeout being too short.

Set PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT=300000 (5 minutes) in all prep and run scripts on both Windows and macOS, before any dotnet restore/build commands that may trigger Playwright browser downloads.

Bumped prep_version: Windows and macOS 6->7