### PR TITLE
net_aspire: regenerate ConfigurationSchema.json during prep

### DIFF
--- a/scenarios/macos/mac_net_aspire/mac_net_aspire.py
+++ b/scenarios/macos/mac_net_aspire/mac_net_aspire.py
@@ -14,7 +14,7 @@ import time
 class MacNetAspire(core.app_scenario.Scenario):
 
     module = __module__.split('.')[-1]
-    prep_version = "7"
+    prep_version = "8"
     resources = module + "_resources"
 
 

--- a/scenarios/macos/mac_net_aspire/mac_net_aspire_resources/mac_net_aspire_prep.sh
+++ b/scenarios/macos/mac_net_aspire/mac_net_aspire_resources/mac_net_aspire_prep.sh
@@ -170,6 +170,19 @@ if [ "$PYTHON_VERSION" != "3.12.10" ]; then
 fi
 log "✓ Python version confirmed: $PYTHON_VERSION"
 
+# -------------------------------------------------------------------
+# Regenerate ConfigurationSchema.json files
+# -------------------------------------------------------------------
+# The Aspire repo validates that checked-in ConfigurationSchema.json files match
+# what the installed SDK generates. A plain build fails validation if they differ.
+# The Aspire CI runs with /p:UpdateConfigurationSchema=true to regenerate them
+# before validation. We do the same here during prep so that subsequent run
+# iterations (which use plain --build) pass cleanly.
+log "-- Regenerating ConfigurationSchema.json files"
+cd $BIN_DIR/aspire
+./build.sh --restore --build /p:UpdateConfigurationSchema=true
+check_status "ConfigurationSchema regeneration"
+
 log ""
 log "✓ All checks passed"
 log "-- net_aspire prep completed successfully"

--- a/scenarios/windows/net_aspire/net_aspire_resources/net_aspire_prep.ps1
+++ b/scenarios/windows/net_aspire/net_aspire_resources/net_aspire_prep.ps1
@@ -221,5 +221,18 @@ dotnet restore Aspire.slnx
 check($lastexitcode)
 "   Restore completed successfully" | log
 
+# -------------------------------------------------------------------
+# Regenerate ConfigurationSchema.json files
+# -------------------------------------------------------------------
+# The Aspire repo validates that checked-in ConfigurationSchema.json files match
+# what the installed SDK generates. A plain 'dotnet build' fails validation if they
+# differ. The Aspire CI pipeline runs with /p:UpdateConfigurationSchema=true to
+# regenerate them before the validation check. We do the same here during prep so
+# that subsequent run iterations (which use plain 'dotnet build') pass cleanly.
+"-- Regenerating ConfigurationSchema.json files" | log
+dotnet build Aspire.slnx --no-incremental /p:UpdateConfigurationSchema=true
+check($lastexitcode)
+"   ConfigurationSchema regeneration completed" | log
+
 "-- net_aspire prep completed ($logSuffix version)" | log
 Exit 0


### PR DESCRIPTION
The .NET Aspire repo's Directory.Build.targets validates that checked-in ConfigurationSchema.json files match what the installed SDK generates. A plain 'dotnet build' fails with 21 errors when they don't match.

Add a one-time schema regeneration step (dotnet build --no-incremental /p:UpdateConfigurationSchema=true) at the end of prep for both Windows and macOS. This ensures subsequent run iterations pass cleanly.

Bump prep_version: Windows 6->7, macOS 7->8.