### PR TITLE
net_aspire: bump Windows prep_version to trigger schema regeneration

### DIFF
--- a/scenarios/windows/net_aspire/net_aspire.py
+++ b/scenarios/windows/net_aspire/net_aspire.py
@@ -14,7 +14,7 @@ from datetime import datetime
 class NetAspire(core.app_scenario.Scenario):
 
     module = __module__.split('.')[-1]
-    prep_version = "7"
+    prep_version = "8"
     resources = module + "_resources"
 
 


### PR DESCRIPTION
Commit 1f67a68 added ConfigurationSchema.json regeneration to the Windows prep script but missed bumping prep_version in net_aspire.py (only macOS was bumped). This caused all run iterations to fail with 21 schema-out-of-date errors because the DUT never re-ran the updated prep.

Bump prep_version 7 -> 8 to match macOS.