### PR TITLE
Rollup Script Update

### DIFF
--- a/utilities/open_source/rollup_metrics.py
+++ b/utilities/open_source/rollup_metrics.py
@@ -56,7 +56,10 @@ def main():
         "*_power_heavy.csv",
         "*_DAQ.csv",
         "srumutil.csv",
-        "*rails.csv"
+        "*rails.csv",
+        "combined_trace_data.csv",
+        "*fan_log.csv",
+        "*temp_log.csv"
     ]
 
     def is_exception(file):

--- a/utilities/open_source/rollup_metrics_json.py
+++ b/utilities/open_source/rollup_metrics_json.py
@@ -61,7 +61,10 @@ def main():
         "scenario_events.csv",
         "*_power_heavy.csv",
         "srumutil.csv",
-        "*_DAQ.csv"
+        "*_DAQ.csv",
+        "combined_trace_data.csv",
+        "*fan_log.csv",
+        "*temp_log.csv"
     ]
 
     def is_exception(file):


### PR DESCRIPTION
Update rollup scripts to skip some thermal specific tool logs that are not formatted correctly for rollup.