### PR TITLE
Fix macOS VS Code scenario build failure on Darwin 25.4+ (macOS Tahoe 26.4)

### DIFF
--- a/scenarios/macos/mac_vscode/mac_vscode.py
+++ b/scenarios/macos/mac_vscode/mac_vscode.py
@@ -14,7 +14,7 @@ import time
 class MacVscode(scenarios.app_scenario.Scenario):
 
     module = __module__.split('.')[-1]
-    prep_version = "5"
+    prep_version = "6"
     resources = module + "_resources"
 
 

--- a/scenarios/macos/mac_vscode/mac_vscode_resources/mac_vscode_prep.sh
+++ b/scenarios/macos/mac_vscode/mac_vscode_resources/mac_vscode_prep.sh
@@ -160,6 +160,27 @@ check_status "VS Code checkout v1.106.2"
 
 # 7. Install npm dependencies
 log "-- Installing npm dependencies (this may take 10-20 minutes)..."
+# First attempt - this will fail on @vscode/spdlog due to Apple Clang consteval issue on Darwin 25.4+
+npm install --loglevel=error 2>/dev/null
+
+# Patch bundled fmt in @vscode/spdlog to work around Apple Clang consteval issue
+SPDLOG_FMT_DIR="node_modules/@vscode/spdlog/deps/spdlog/include/spdlog/fmt/bundled"
+if [ -d "$SPDLOG_FMT_DIR" ]; then
+    log "-- Patching spdlog fmt headers (consteval -> constexpr)"
+    sed -i '' 's/consteval/constexpr/g' "$SPDLOG_FMT_DIR/format.h"
+    sed -i '' 's/consteval/constexpr/g' "$SPDLOG_FMT_DIR/core.h"
+    check_status "spdlog fmt patch"
+
+    # Rebuild just spdlog with the patched source (npm uses its bundled node-gyp)
+    log "-- Rebuilding @vscode/spdlog..."
+    npm rebuild @vscode/spdlog
+    check_status "spdlog rebuild"
+else
+    log "-- No spdlog fmt patch needed"
+fi
+
+# Re-run npm install to complete any remaining steps (postinstall, etc.)
+log "-- Completing npm install..."
 npm install --loglevel=error
 check_status "npm install"
 


### PR DESCRIPTION
### Problem

The `mac_vscode` scenario fails during prep on machines running macOS Tahoe 26.4 or later (Darwin 25.4.0+). The `npm install` step crashes when compiling `@vscode/spdlog` (v0.15.2), which bundles an older version of the `fmt` C++ library.

Apple Clang 21.0.0 (shipped with Xcode CLT on Darwin 25.4) is stricter about `consteval` evaluation and rejects `fmt`'s `FMT_STRING` macro and `basic_format_string` constructor in `core.h` and `format.h`:

```
error: call to consteval function 'fmt::basic_format_string<...>::basic_format_string<FMT_COMPILE_STRING, 0>'
       is not a constant expression
```

This blocks all VS Code scenario runs on any Mac that has been updated to macOS 26.4+.

### Fix

Modified `mac_vscode_prep.sh` to work around the incompatibility using a three-step approach:

1. **Run `npm install`** — completes normally for all packages except `@vscode/spdlog`, which fails during its native build
2. **Patch the bundled `fmt` headers** — uses `sed` to replace `consteval` with `constexpr` in both `format.h` and `core.h` under `@vscode/spdlog/deps/spdlog/include/spdlog/fmt/bundled/`
3. **Rebuild just `@vscode/spdlog`** — `npm rebuild @vscode/spdlog` recompiles the native module with the patched source using npm's bundled node-gyp
4. **Re-run `npm install`** — picks up the now-built spdlog and completes any remaining postinstall steps

This approach preserves the normal `npm install` flow (postinstall scripts, extensions dependencies, etc.) while surgically fixing just the broken native module.

### Root Cause

- **macOS Tahoe 26.4** (released March 24, 2026) ships Darwin 25.4.0 with Apple Clang 21.0.0
- Clang 21 enforces stricter `consteval` constant expression evaluation
- VS Code 1.106.2 depends on `@vscode/spdlog ^0.15.2` which bundles `fmt` v8.x with `consteval` code that doesn't satisfy the stricter checks
- The upstream `fmt` library fixed this in later versions, but `@vscode/spdlog` hasn't updated its bundled copy

### Testing

- Verified on MacBook Pro M4 Pro running macOS Tahoe 26.4 (Darwin 25.4.0)
- `npm install` + patch + rebuild completes successfully
- VS Code build compiles and runs correctly after prep