### PR TITLE
windows: refresh PATH and assert required tools in scenario run scripts

### DIFF
--- a/scenarios/windows/fast_api/fast_api.py
+++ b/scenarios/windows/fast_api/fast_api.py
@@ -14,7 +14,7 @@ from datetime import datetime
 class FastApi(core.app_scenario.Scenario):
 
     module = __module__.split('.')[-1]
-    prep_version = "4"
+    prep_version = "5"
     resources = module + "_resources"
 
 

--- a/scenarios/windows/fast_api/fast_api_resources/fast_api_run.ps1
+++ b/scenarios/windows/fast_api/fast_api_resources/fast_api_run.ps1
@@ -281,6 +281,19 @@ Set-OptimizedPathOrder
 # PATH is now optimized: pyenv first (from User PATH), then system dirs (from Machine PATH)
 # Windows Store Python is at the end with lowest priority
 
+# Verify required commands are findable on PATH after Set-OptimizedPathOrder.
+# Fail fast with a clear diagnostic instead of a chain of "term not recognized" errors.
+foreach ($cmd in @('pyenv', 'python')) {
+    $resolved = Get-Command $cmd -ErrorAction SilentlyContinue
+    if (-not $resolved) {
+        " ERROR - Required command '$cmd' not found on PATH after PATH optimization." | log
+        " ERROR - Prep may not have completed, or the RPC service has a stale PATH." | log
+        " ERROR - PATH: $env:Path" | log
+        Exit 1
+    }
+    "Found ${cmd}: $($resolved.Source)" | log
+}
+
 Set-Location "$scriptDrive\FastAPI"
 
 "Setting Python global version to $pythonVersion..." | log

--- a/scenarios/windows/foundrylocal/foundrylocal.py
+++ b/scenarios/windows/foundrylocal/foundrylocal.py
@@ -14,7 +14,7 @@ import time
 class Foundrylocal(core.app_scenario.Scenario):
 
     module = __module__.split('.')[-1]
-    prep_version = "6"
+    prep_version = "7"
     resources = module + "_resources"
 
 

--- a/scenarios/windows/foundrylocal/foundrylocal_resources/foundrylocal_run.ps1
+++ b/scenarios/windows/foundrylocal/foundrylocal_resources/foundrylocal_run.ps1
@@ -109,6 +109,19 @@ Write-RunPhaseMarker "phase.run_prep.start"
 # Refresh PATH to ensure foundry is available
 $Env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
 
+# Verify required commands are findable on PATH after refresh.
+# Fail fast with a clear diagnostic instead of a chain of "term not recognized" errors.
+foreach ($cmd in @('foundry')) {
+    $resolved = Get-Command $cmd -ErrorAction SilentlyContinue
+    if (-not $resolved) {
+        " ERROR - Required command '$cmd' not found on PATH after refresh." | log
+        " ERROR - Prep may not have completed, or the RPC service has a stale PATH." | log
+        " ERROR - PATH: $env:Path" | log
+        Exit 1
+    }
+    "Found ${cmd}: $($resolved.Source)" | log
+}
+
 # Output directory for results
 $outputDir = "$scriptDrive\hobl_data"
 if (-not (Test-Path $outputDir)) {

--- a/scenarios/windows/llvm/llvm.py
+++ b/scenarios/windows/llvm/llvm.py
@@ -14,7 +14,7 @@ from datetime import datetime
 class Llvm(scenarios.app_scenario.Scenario):
 
     module = __module__.split('.')[-1]
-    prep_version = "7"
+    prep_version = "8"
     resources = module + "_resources"
 
 

--- a/scenarios/windows/llvm/llvm_resources/llvm_run.ps1
+++ b/scenarios/windows/llvm/llvm_resources/llvm_run.ps1
@@ -132,6 +132,19 @@ Write-RunPhaseMarker "phase.run_prep.start"
 
 $Env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
 
+# Verify required commands are findable on PATH after refresh.
+# Fail fast with a clear diagnostic instead of a chain of "term not recognized" errors.
+foreach ($cmd in @('ninja')) {
+    $resolved = Get-Command $cmd -ErrorAction SilentlyContinue
+    if (-not $resolved) {
+        " ERROR - Required command '$cmd' not found on PATH after refresh." | log
+        " ERROR - Prep may not have completed, or the RPC service has a stale PATH." | log
+        " ERROR - PATH: $env:Path" | log
+        Exit 1
+    }
+    "Found ${cmd}: $($resolved.Source)" | log
+}
+
 # --- Initialize Visual Studio Developer Command environment ---
 # VsDevCmd.bat sets up LIB, INCLUDE, and PATH so that MSVC libraries and headers
 # are discoverable during the build (e.g., ATL/MFC, Windows SDK, UCRT).

--- a/scenarios/windows/net_aspire/net_aspire.py
+++ b/scenarios/windows/net_aspire/net_aspire.py
@@ -14,7 +14,7 @@ from datetime import datetime
 class NetAspire(core.app_scenario.Scenario):
 
     module = __module__.split('.')[-1]
-    prep_version = "8"
+    prep_version = "9"
     resources = module + "_resources"
 
 

--- a/scenarios/windows/net_aspire/net_aspire_resources/net_aspire_run.ps1
+++ b/scenarios/windows/net_aspire/net_aspire_resources/net_aspire_run.ps1
@@ -51,6 +51,18 @@ function Write-RunPhaseMarker {
 # Configuration
 $scriptDrive = Split-Path -Qualifier $PSScriptRoot
 
+# Refresh PATH from Machine+User environment so dotnet (installed via winget during prep)
+# is visible to this session. The HOBL RPC service started before prep ran, so the inherited
+# PATH is stale and does not include C:\Program Files\dotnet without this refresh.
+$env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
+
+# Fallback: ensure the default dotnet install directory is on PATH even if the env var
+# was not updated (e.g. dotnet installed by a non-winget installer that did not update PATH).
+$dotnetDir = "C:\Program Files\dotnet"
+if ((Test-Path "$dotnetDir\dotnet.exe") -and (";$env:Path;" -notlike "*;$dotnetDir;*")) {
+    $env:Path = "$dotnetDir;$env:Path"
+}
+
 if (-not (Test-Path "$scriptDrive\hobl_data")) {
     Write-Host " ERROR - Required directory not found: $scriptDrive\hobl_data" -ForegroundColor Red
     Exit 1
@@ -125,7 +137,13 @@ if (-not (Test-Path ".\Aspire.slnx")) {
 # that doesn't inherit env vars set during prep.
 $env:DOTNET_INSTALL_DIR = "C:\Program Files\dotnet"
 "-- DOTNET_INSTALL_DIR set to '$($env:DOTNET_INSTALL_DIR)' (prevents Arcade SDK from downloading x64 runtimes)" | log
-"-- dotnet on PATH: $(Get-Command dotnet -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source)" | log
+$dotnetCmd = Get-Command dotnet -ErrorAction SilentlyContinue
+if (-not $dotnetCmd) {
+    " ERROR - dotnet not found on PATH. Prep may not have completed, or PATH was not refreshed." | log
+    " ERROR - PATH: $env:Path" | log
+    Exit 1
+}
+"-- dotnet on PATH: $($dotnetCmd.Source)" | log
 "-- Active SDK version: $(dotnet --version 2>&1)" | log
 "-- All installed SDKs:" | log
 dotnet --list-sdks 2>&1 | ForEach-Object { "   $_" | log }

--- a/scenarios/windows/net_aspire/net_aspire_resources/net_aspire_teardown.ps1
+++ b/scenarios/windows/net_aspire/net_aspire_resources/net_aspire_teardown.ps1
@@ -10,6 +10,15 @@ if (-not $logFile) { $logFile = "$scriptDrive\hobl_data\net_aspire_teardown.log"
 
 [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
 
+# Refresh PATH from Machine+User environment so dotnet (installed via winget during prep)
+# is visible to this session. The HOBL RPC service started before prep ran, so the inherited
+# PATH is stale and does not include C:\Program Files\dotnet without this refresh.
+$env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
+$dotnetDir = "C:\Program Files\dotnet"
+if ((Test-Path "$dotnetDir\dotnet.exe") -and (";$env:Path;" -notlike "*;$dotnetDir;*")) {
+    $env:Path = "$dotnetDir;$env:Path"
+}
+
 # Determine processor architecture for log file naming
 $osInfo = Get-CimInstance Win32_OperatingSystem
 $arch = $osInfo.OSArchitecture

--- a/scenarios/windows/nodejs/nodejs.py
+++ b/scenarios/windows/nodejs/nodejs.py
@@ -14,7 +14,7 @@ from datetime import datetime
 class Nodejs(core.app_scenario.Scenario):
 
     module = __module__.split('.')[-1]
-    prep_version = "6"
+    prep_version = "7"
     resources = module + "_resources"
 
 

--- a/scenarios/windows/nodejs/nodejs_resources/nodejs_run.ps1
+++ b/scenarios/windows/nodejs/nodejs_resources/nodejs_run.ps1
@@ -136,6 +136,20 @@ function getVSVersion {
 "-- Initializing Visual Studio Developer Command environment" | log
 $Env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
 
+# Verify required commands are findable on PATH after refresh.
+# Fail fast with a clear diagnostic instead of a chain of "term not recognized" errors.
+# pyenv check is done before we prepend pyenv paths below; pyenv must be installed by prep.
+foreach ($cmd in @('pyenv')) {
+    $resolved = Get-Command $cmd -ErrorAction SilentlyContinue
+    if (-not $resolved) {
+        " ERROR - Required command '$cmd' not found on PATH after refresh." | log
+        " ERROR - Prep may not have completed, or the RPC service has a stale PATH." | log
+        " ERROR - PATH: $env:Path" | log
+        Exit 1
+    }
+    "Found ${cmd}: $($resolved.Source)" | log
+}
+
 $vsInfo = getVSVersion -product $vsProduct
 if (-not $vsInfo -or -not $vsInfo.Path) {
     " ERROR - Visual Studio $vsProduct installation not found via vswhere" | log

--- a/scenarios/windows/ollama/ollama.py
+++ b/scenarios/windows/ollama/ollama.py
@@ -14,7 +14,7 @@ from datetime import datetime
 class Ollama(core.app_scenario.Scenario):
 
     module = __module__.split('.')[-1]
-    prep_version = "5"
+    prep_version = "6"
     resources = module + "_resources"
 
 

--- a/scenarios/windows/ollama/ollama_resources/ollama_run.ps1
+++ b/scenarios/windows/ollama/ollama_resources/ollama_run.ps1
@@ -112,6 +112,19 @@ Write-RunPhaseMarker "phase.run_prep.start"
 
 $Env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
 
+# Verify required commands are findable on PATH after refresh.
+# Fail fast with a clear diagnostic instead of a chain of "term not recognized" errors.
+foreach ($cmd in @('go')) {
+    $resolved = Get-Command $cmd -ErrorAction SilentlyContinue
+    if (-not $resolved) {
+        " ERROR - Required command '$cmd' not found on PATH after refresh." | log
+        " ERROR - Prep may not have completed, or the RPC service has a stale PATH." | log
+        " ERROR - PATH: $env:Path" | log
+        Exit 1
+    }
+    "Found ${cmd}: $($resolved.Source)" | log
+}
+
 Set-Location "$scriptDrive\ollama"
 
 # Disable Progress indicator

--- a/scenarios/windows/opencv_build/opencv_build.py
+++ b/scenarios/windows/opencv_build/opencv_build.py
@@ -13,7 +13,7 @@ from datetime import datetime
 class OpencvBuild(core.app_scenario.Scenario):
 
     module = __module__.split('.')[-1]
-    prep_version = "5"
+    prep_version = "6"
     resources = module + "_resources"
 
 

--- a/scenarios/windows/opencv_build/opencv_build_resources/opencv_build_run.ps1
+++ b/scenarios/windows/opencv_build/opencv_build_resources/opencv_build_run.ps1
@@ -100,6 +100,19 @@ Write-RunPhaseMarker "phase.run_prep.start"
 
 $Env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
 
+# Verify required commands are findable on PATH after refresh.
+# Fail fast with a clear diagnostic instead of a chain of "term not recognized" errors.
+foreach ($cmd in @('cmake')) {
+    $resolved = Get-Command $cmd -ErrorAction SilentlyContinue
+    if (-not $resolved) {
+        " ERROR - Required command '$cmd' not found on PATH after refresh." | log
+        " ERROR - Prep may not have completed, or the RPC service has a stale PATH." | log
+        " ERROR - PATH: $env:Path" | log
+        Exit 1
+    }
+    "Found ${cmd}: $($resolved.Source)" | log
+}
+
 $time = Get-Date -Format "HH:mm:ss"
 "$time - Clean build files" | log
 

--- a/scenarios/windows/pytorch_inf/pytorch_inf.py
+++ b/scenarios/windows/pytorch_inf/pytorch_inf.py
@@ -14,7 +14,7 @@ from datetime import datetime
 class PytorchInf(core.app_scenario.Scenario):
 
     module = __module__.split('.')[-1]
-    prep_version = "12"
+    prep_version = "13"
     # prep_scenarios = [(module, prep_version)]
     resources = module + "_resources"
 

--- a/scenarios/windows/pytorch_inf/pytorch_inf_resources/pytorch_inf_run.ps1
+++ b/scenarios/windows/pytorch_inf/pytorch_inf_resources/pytorch_inf_run.ps1
@@ -244,6 +244,19 @@ function Set-OptimizedPathOrder {
 
 Set-OptimizedPathOrder
 
+# Verify required commands are findable on PATH after Set-OptimizedPathOrder.
+# Fail fast with a clear diagnostic instead of a chain of "term not recognized" errors.
+foreach ($cmd in @('pyenv', 'python')) {
+    $resolved = Get-Command $cmd -ErrorAction SilentlyContinue
+    if (-not $resolved) {
+        " ERROR - Required command '$cmd' not found on PATH after PATH optimization." | log
+        " ERROR - Prep may not have completed, or the RPC service has a stale PATH." | log
+        " ERROR - PATH: $env:Path" | log
+        Exit 1
+    }
+    "Found ${cmd}: $($resolved.Source)" | log
+}
+
 "Setting Python global version to $pythonVersion..." | log
 pyenv global $pythonVersion
 if ($LASTEXITCODE -ne 0) {

--- a/scenarios/windows/vscode/vscode.py
+++ b/scenarios/windows/vscode/vscode.py
@@ -14,7 +14,7 @@ import time
 class Vscode(scenarios.app_scenario.Scenario):
 
     module = __module__.split('.')[-1]
-    prep_version = "7"
+    prep_version = "8"
     resources = module + "_resources"
 
 

--- a/scenarios/windows/vscode/vscode_resources/vscode_run.ps1
+++ b/scenarios/windows/vscode/vscode_resources/vscode_run.ps1
@@ -146,6 +146,19 @@ $Env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";
 # Re-prepend pyenv paths after PATH refresh
 $env:PATH = "$pyenvRoot\pyenv-win\bin;$pyenvRoot\pyenv-win\shims;$pythonDir;$env:PATH"
 
+# Verify required commands are findable on PATH after refresh.
+# Fail fast with a clear diagnostic instead of a chain of "term not recognized" errors.
+foreach ($cmd in @('pyenv', 'npm')) {
+    $resolved = Get-Command $cmd -ErrorAction SilentlyContinue
+    if (-not $resolved) {
+        " ERROR - Required command '$cmd' not found on PATH after refresh." | log
+        " ERROR - Prep may not have completed, or the RPC service has a stale PATH." | log
+        " ERROR - PATH: $env:Path" | log
+        Exit 1
+    }
+    "Found ${cmd}: $($resolved.Source)" | log
+}
+
 # Navigate to VS Code directory
 if (-not (Test-Path $vscodePath)) {
     " ERROR - VS Code directory not found: $vscodePath. Run vscode_prep.ps1 first." | log


### PR DESCRIPTION
The HOBL RPC service on the DUT captures PATH at boot. When a scenario prep script installs tools via winget, those tools land in the Machine PATH but the RPC service's inherited PATH is stale, so pwsh sessions spawned afterward cannot find them. Combined with prep_status persistence skipping prep on subsequent runs, this caused net_aspire to fail with cryptic 'dotnet not recognized' errors.

Fix:

- net_aspire_run.ps1 / net_aspire_teardown.ps1: add Machine+User PATH refresh plus a fallback C:\\Program Files\\dotnet PATH prepend (this is the actually-broken script). Bump prep_version 8 -> 9.

- All other Windows run scripts already had the PATH refresh but invoked tools blindly. Add a Get-Command assertion block right after the refresh that lists each required tool, logs a single clear ERROR line and PATH dump on miss, and exits 1 instead of letting the shell emit a chain of 'term not recognized' messages.

Affected scenarios (assertion + prep_version bump):

  net_aspire (8->9), foundrylocal (6->7), ollama (5->6), llvm (7->8), nodejs (6->7), opencv_build (5->6), vscode (7->8), pytorch_inf (12->13), fast_api (4->5)

Skipped (no PATH-resolved external tools to assert):

  mlperf (uses absolute path to mlperf-windows.exe), spring_petclinic (uses local .\\mvnw.cmd and locates JDK via Get-ChildItem)