### PR TITLE
Enhance Cinebench reporting and local installer support

### DIFF
--- a/scenarios/windows/cinebench.py
+++ b/scenarios/windows/cinebench.py
@@ -15,27 +15,28 @@ class Cinebench(core.app_scenario.Scenario):
 
     Params.setDefault(module, 'duration', '60', desc="Minimum run time in seconds")
     Params.setDefault(module, 'workload', 'multi_core', desc="Workload type: single_core or multi_core", valOptions=["single_core", "multi_core"])
+    Params.setDefault(module, 'installer_path', '', desc="Path to Cinebench installer on host machine. This should be the directory for your device architecture, containing the extracted Cinebench files, including cinebench.exe")
     prep_version = "1"
 
-    def setUp(self):    
+    def setUp(self):
+        self.toolCallBacks("testBeginEarlyCallback")
+        
         self.duration = int(Params.get(self.module, 'duration'))
         self.workload = Params.get(self.module, 'workload')
         self.dut_arch = Params.get('global', 'dut_architecture')
 
-        self.package_name = f"cinebench-2024-{self.dut_arch}"
-        self.cinebench_path = f"c:\\{self.package_name}\\cb_2024.exe"
+        installer_path = Params.get(self.module, 'installer_path')
+
+        # Get the name of the folder that was uploaded to the device, which should be the same as the last part of the installer path
+        self.folder_name = installer_path.split('\\')[-1]
+        
+        self.cinebench_path = f"{self.dut_exec_path}\\Cinebench\\{self.folder_name}\\cinebench.exe"
         self.out_filename = "cinebench_output.txt"
 
-        host_path = f"scenarios\\cinebench_resources\\{self.package_name}"
         # Test if already set up
         if self.checkPrepStatus([self.module + self.prep_version]):
-            self._check_and_download(f"{self.package_name}", path = "scenarios\\cinebench_resources")
-            # Rename local cinebench.exe on host to avoid benchmark blocker
-            if not os.path.exists(f"{host_path}\\cb_2024.exe"):
-                os.rename(f"{host_path}\\cinebench.exe", f"{host_path}\\cb_2024.exe")
-            self._upload(f"{host_path}", "c:\\")
+            self._upload(f"{installer_path}", f"{self.dut_exec_path}\\Cinebench")
             self.createPrepStatusControlFile(self.prep_version)
-
         super().setUp()
 
 
@@ -51,6 +52,9 @@ class Cinebench(core.app_scenario.Scenario):
 
     def tearDown(self):
         logging.info("Tearing down Cinebench scenario.")
+        # Baseclass test end callback to stop tools
+        self._callback(Params.get('global', 'callback_test_end'))
+
         # Download output file
         self._copy_data_from_remote(dest = self.result_dir, source = self.dut_data_path + '\\' + self.out_filename, single_file=True)
 
@@ -69,7 +73,13 @@ class Cinebench(core.app_scenario.Scenario):
 
         # Write score to cinebench.csv
         with open(self.result_dir + '\\cinebench.csv', 'w') as out:
-            out.write(f"Cinebench Score,{score}\n")
+            if self.workload == 'single_core':
+                out.write(f"Cinebench Single Core Score,{score}\n")
+            else:
+                out.write(f"Cinebench Multi Core Score,{score}\n")
 
-        super().tearDown()
-        logging.info(f"Cinebench score: {score}")
+        super().tearDown(callback_test_end="")
+        if self.workload == 'single_core':
+            logging.info(f"Cinebench Single Core score: {score}")
+        else:
+            logging.info(f"Cinebench Multi Core score: {score}")


### PR DESCRIPTION
- Update Cinebench to report which workload was used along with the score (single core vs multi core). 
- Update the Cinebench install to allow users to point to a local installer location.
- Remove code renaming Cinebench executable on dut