### PR TITLE
Fix/per scenario venv isolation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -69,6 +69,103 @@ When logging or displaying error messages in PowerShell scripts:
   ```
 - When passing Python paths to tools like CMake (`-DPython3_EXECUTABLE`), the path must point to the actual `.exe`, not a shim/batch file
 
+### Shared-State Hazards Across Scenarios (CRITICAL — read before touching any prep script)
+
+Multiple HOBL scenarios share the same pyenv-managed Python version (Windows: `3.12.10-arm` is used by `pytorch_inf`, `llvm`, `nodejs`, `vscode`, `opencv_build`, `fast_api`; macOS: `3.12.10` is used by `mac_pytorch_inf`, `mac_llvm`, `mac_nodejs`, `mac_opencv_build`, `mac_net_aspire`). When several scenarios share a single pyenv version directory, **anything one scenario does to that directory affects every other scenario**.
+
+The most damaging operation observed in production was `pyenv install <version> -f`, which deletes and re-extracts the entire `~\.pyenv\pyenv-win\versions\<version>\` directory — including `Lib\site-packages\`. A single scenario's prep silently wiped torch (and every other pip-installed package) from another scenario's site-packages. Because HOBL's `prep_status` file says prep is "done," the next iteration skipped prep and failed cryptically.
+
+**Rules to prevent this class of bug:**
+
+- **Never** use force flags on version-manager installs that target shared toolchains:
+  - ❌ `pyenv install <version> -f` (Windows or macOS)
+  - ❌ `nvm install <version> --reinstall-packages-from=<other>` (clobbers a shared Node)
+  - ❌ `brew reinstall <pkg>` for a `brew` package another scenario depends on
+  - ❌ `rustup toolchain install <toolchain> --force-non-host`
+
+  Replace with a conditional install pattern:
+
+  Windows:
+  ```powershell
+  $installedVersions = (pyenv versions --bare 2>$null) -split "`n" | ForEach-Object { $_.Trim() }
+  if ($installedVersions -notcontains $pythonVersion) {
+      "Installing Python $pythonVersion via pyenv..." | log
+      pyenv install $pythonVersion
+      check($lastexitcode)
+  } else {
+      "Python $pythonVersion already installed via pyenv — preserving existing install" | log
+  }
+  ```
+  macOS (bash):
+  ```bash
+  if ! pyenv versions --bare | grep -qx "$PYTHON_VERSION"; then
+      log "Installing Python $PYTHON_VERSION via pyenv..."
+      pyenv install "$PYTHON_VERSION"
+  else
+      log "Python $PYTHON_VERSION already installed via pyenv — preserving existing install"
+  fi
+  ```
+
+- **Never** `pip install` directly into the shared pyenv site-packages. Always create a **per-scenario venv** at `<scriptDrive>\hobl_bin\<scenario>_resources\.venv\` (Windows) or `$BIN_DIR/<scenario>_resources/.venv/` (macOS). All `pip install` calls must target the venv's pip via absolute path.
+
+  Windows venv creation pattern (in prep.ps1, after pyenv is set up):
+  ```powershell
+  $venvDir = "$scriptDrive\hobl_bin\<scenario>_resources\.venv"
+  $pyenvPython = (pyenv which python 2>$null).Trim()
+  if (-not (Test-Path $pyenvPython)) {
+      " ERROR - pyenv python not found at: $pyenvPython" | log
+      Exit 1
+  }
+  if (Test-Path $venvDir) { Remove-Item -Recurse -Force $venvDir }
+  & $pyenvPython -m venv $venvDir
+  check($lastexitcode)
+
+  $venvPython = Join-Path $venvDir "Scripts\python.exe"
+  $venvPip    = Join-Path $venvDir "Scripts\pip.exe"
+
+  & $venvPip install -r requirements.txt
+  check($lastexitcode)
+  ```
+  macOS equivalent uses `bin/python` and `bin/pip` instead of `Scripts/`.
+
+- **Never** `pip install --upgrade pip` in a venv. The pip bundled with the pinned Python release is what we want — reproducible across DUTs, no network dependency.
+
+- **Always** invoke the venv's python by absolute path in run.ps1 / teardown.ps1 — never via `python` on PATH:
+  ```powershell
+  $venvPython = "$scriptDrive\hobl_bin\<scenario>_resources\.venv\Scripts\python.exe"
+  if (-not (Test-Path $venvPython)) {
+      " ERROR - venv missing at $venvPython. Re-prep required:" | log
+      " ERROR -   delete C:\hobl_bin\prep_status\<scenario><version> on the DUT and re-run." | log
+      Exit 1
+  }
+  & $venvPython script.py args
+  ```
+
+- **Always** validate critical imports at the top of run.ps1 with a fail-fast guard. This converts a cryptic `ModuleNotFoundError` 200 lines into the workload into an actionable error message at run start:
+  ```powershell
+  & $venvPython -c "import torch, transformers; print('torch', torch.__version__)" 2>&1 | log
+  if ($LASTEXITCODE -ne 0) {
+      " ERROR - venv has missing/broken Python packages." | log
+      " ERROR - Possible causes: Defender quarantine, disk cleanup, or external tampering." | log
+      " ERROR - Re-prep required: delete C:\hobl_bin\prep_status\<scenario><version> on the DUT and re-run." | log
+      Exit 1
+  }
+  ```
+
+- **The venv survives `pyenv install -f` from other scenarios** because it lives outside the pyenv version directory. Even if a defensive boundary breaks elsewhere, the venv directory and its site-packages are untouched. (On Windows, the venv even survives a Python force-reinstall as long as it's the same major.minor.patch version — see the Python venv docs for details.)
+
+- **The `prep_status` file alone is not a reliable signal that prep artifacts are still present.** External actors (Microsoft Defender quarantine, OS re-imaging, Windows Update, lab tech intervention) can remove prep-installed files without HOBL knowing. The run-time import validation guard above is the durable defense against this.
+
+### Diagnosing Scenario Failures After iter 0 Succeeded
+
+When a scenario succeeds on iter 0 but fails on subsequent iters with what looks like missing dependencies, check **in this order**:
+
+1. **What `prep_status` file does the DUT have?** Look in `hobl.log` for the `if exist C:\hobl_bin\prep_status\<scenario><N>` RPC call. If `<N>` doesn't match the host's current `prep_version` value, **the host hasn't been updated** — the lab's local clone needs `git pull`.
+2. **Did another scenario between iter 0 and the failing iter call `pyenv install -f`?** Search intermediate scenarios' preps for the pattern. If yes, this PR's venv pattern is the fix.
+3. **Was anything quarantined by Defender?** Check Windows Event Viewer → Microsoft → Windows → Windows Defender → Operational.
+4. **Was the DUT re-imaged between iterations?** Look at the study profile's `os_install` parameter and timestamps on `C:\Users\<user>` vs. `C:\hobl_bin\prep_status\`.
+5. **Did `pyenv global` get switched by another scenario's prep?** Run `pyenv version` on the DUT; should match what the failing scenario expects.
+
 ### Execution Policy for PowerShell Archive Module
 - Scripts that use `pyenv install` (which internally calls `Expand-Archive`) must set the execution policy at the top of the script
 - Without this, `Microsoft.PowerShell.Archive` module fails to load on fresh Windows installs
@@ -120,7 +217,9 @@ macOS-only additional keys (from `/usr/bin/time -p`):
 
 ### Prep Version Bumping
 - Each developer scenario has a `prep_version` string in its Python file (e.g., `prep_version = "2"`) that controls whether the prep script re-runs on the DUT
-- **Whenever prep or run PowerShell/shell scripts are modified in a PR**, increment `prep_version` by 1 in the corresponding scenario's Python file (both Windows and macOS)
+- **When a prep change REQUIRES re-execution on existing DUTs** (e.g., a different Python version, a new mandatory dependency, a changed install path), increment `prep_version` by 1 in the corresponding scenario's Python file (both Windows and macOS).
+- **When a prep change is purely defensive and safe to re-apply against existing state** (e.g., replacing `pyenv install -f` with a conditional install that's a no-op when the version exists), **do NOT bump prep_version**. Bumping forces every lab DUT to re-prep, which can take 10–15 minutes per scenario across the whole fleet. The fix should ship without forcing a re-prep wave.
+- Decision rule: ask "if this prep is skipped on an existing DUT, will the run still work correctly?" If yes → don't bump. If no → bump.
 - This only needs to happen **once per PR** — not per commit
 - Always increment for both platforms if both were changed, or just the affected platform if only one was modified
 

--- a/scenarios/macos/mac_fast_api/mac_fast_api.py
+++ b/scenarios/macos/mac_fast_api/mac_fast_api.py
@@ -14,7 +14,7 @@ import time
 class MacFastApi(core.app_scenario.Scenario):
 
     module = __module__.split('.')[-1]
-    prep_version = "6"
+    prep_version = "7"
     resources = module + "_resources"
 
 

--- a/scenarios/macos/mac_fast_api/mac_fast_api.py
+++ b/scenarios/macos/mac_fast_api/mac_fast_api.py
@@ -14,7 +14,7 @@ import time
 class MacFastApi(core.app_scenario.Scenario):
 
     module = __module__.split('.')[-1]
-    prep_version = "5"
+    prep_version = "6"
     resources = module + "_resources"
 
 

--- a/scenarios/macos/mac_fast_api/mac_fast_api_resources/mac_fast_api_prep.sh
+++ b/scenarios/macos/mac_fast_api/mac_fast_api_resources/mac_fast_api_prep.sh
@@ -169,18 +169,18 @@ source ~/.zprofile
 # Verify pyenv is available
 check_command "pyenv" || exit 1
 
-log "-- Installing Python 3.11.9"
-pyenv install 3.11.9 -f
-check_status "Python 3.11.9 installation"
+log "-- Installing Python 3.12.10"
+pyenv install 3.12.10 -f
+check_status "Python 3.12.10 installation"
 
 log "-- Setting Python version"
-pyenv global 3.11.9
+pyenv global 3.12.10
 check_status "Setting Python global version"
 
 # Verify Python version
 PYTHON_VERSION=$(python --version 2>&1 | awk '{print $2}')
-if [ "$PYTHON_VERSION" != "3.11.9" ]; then
-    log " ERROR - Python version is $PYTHON_VERSION, expected 3.11.9"
+if [ "$PYTHON_VERSION" != "3.12.10" ]; then
+    log " ERROR - Python version is $PYTHON_VERSION, expected 3.12.10"
     pyenv versions
     exit 1
 fi

--- a/scenarios/macos/mac_fast_api/mac_fast_api_resources/mac_fast_api_run.sh
+++ b/scenarios/macos/mac_fast_api/mac_fast_api_resources/mac_fast_api_run.sh
@@ -110,13 +110,13 @@ BIN_DIR="/Users/Shared/hobl_bin/fastapi"
 
 # Set Python version
 log "-- Setting Python version"
-pyenv global 3.11.9
+pyenv global 3.12.10
 check_status "Setting Python global version"
 
 # Verify Python version
 PYTHON_VERSION=$(python --version 2>&1 | awk '{print $2}')
-if [ "$PYTHON_VERSION" != "3.11.9" ]; then
-    log " ERROR - Python version is $PYTHON_VERSION, expected 3.11.9"
+if [ "$PYTHON_VERSION" != "3.12.10" ]; then
+    log " ERROR - Python version is $PYTHON_VERSION, expected 3.12.10"
     pyenv versions
     exit 1
 fi

--- a/scenarios/macos/mac_fast_api/mac_fast_api_resources/mac_fast_api_run.sh
+++ b/scenarios/macos/mac_fast_api/mac_fast_api_resources/mac_fast_api_run.sh
@@ -156,7 +156,11 @@ log "✓ Build module is available"
 
 log "-- fast_api build started"
 
-/usr/bin/time -p -o "$LOG_DIR/mac_fast_api_build_time.log" python -m build
+# Redirect output to a per-phase log so it is preserved in the results share.
+# Without redirection, stdout goes only to the RPC buffer and is lost on timeout.
+BUILD_LOG="$LOG_DIR/mac_fast_api_build.log"
+log "-- Build output: $BUILD_LOG"
+/usr/bin/time -p -o "$LOG_DIR/mac_fast_api_build_time.log" python -m build > "$BUILD_LOG" 2>&1
 check_status "Building Fast API"
 
 # Parse build phase timing
@@ -166,7 +170,9 @@ log "-- fast_api build ended"
 
 log "-- fast_api tests started"
 
-/usr/bin/time -p -o "$LOG_DIR/mac_fast_api_test_time.log" bash scripts/test.sh
+TEST_LOG="$LOG_DIR/mac_fast_api_test.log"
+log "-- Test output: $TEST_LOG"
+/usr/bin/time -p -o "$LOG_DIR/mac_fast_api_test_time.log" bash scripts/test.sh > "$TEST_LOG" 2>&1
 check_status "Running Fast API tests"
 
 # Parse test phase timing

--- a/scenarios/macos/mac_llvm/mac_llvm.py
+++ b/scenarios/macos/mac_llvm/mac_llvm.py
@@ -14,7 +14,7 @@ import time
 class MacLlvm(scenarios.app_scenario.Scenario):
 
     module = __module__.split('.')[-1]
-    prep_version = "5"
+    prep_version = "6"
     resources = module + "_resources"
 
 

--- a/scenarios/macos/mac_llvm/mac_llvm_resources/mac_llvm_run.sh
+++ b/scenarios/macos/mac_llvm/mac_llvm_resources/mac_llvm_run.sh
@@ -141,12 +141,18 @@ ninja -t clean 2>/dev/null || log "   No previous build to clean"
 CORES=$(sysctl -n hw.ncpu)
 log "-- Building LLVM with $CORES cores"
 
+# Redirect ninja output to a per-phase log so it is preserved in the results
+# share. Without redirection, stdout goes only to the RPC buffer and is lost
+# on timeout (LLVM is the longest scenario, so this risk is real).
+BUILD_LOG="$DATA_DIR/mac_llvm_build.log"
+log "-- Build output: $BUILD_LOG"
+
 # Build LLVM with timing
-/usr/bin/time -p -o "$DATA_DIR/mac_llvm_build_time.log" ninja -j$CORES
+/usr/bin/time -p -o "$DATA_DIR/mac_llvm_build_time.log" ninja -j$CORES > "$BUILD_LOG" 2>&1
 BUILD_STATUS=$?
 
 if [ $BUILD_STATUS -ne 0 ]; then
-    log " ERROR - LLVM build failed with exit code $BUILD_STATUS"
+    log " ERROR - LLVM build failed with exit code $BUILD_STATUS. See $BUILD_LOG for details."
     exit 1
 fi
 log "✓ LLVM build completed successfully"

--- a/scenarios/macos/mac_mlperf/mac_mlperf.py
+++ b/scenarios/macos/mac_mlperf/mac_mlperf.py
@@ -14,7 +14,7 @@ import time
 class MacMlperf(core.app_scenario.Scenario):
 
     module = __module__.split('.')[-1]
-    prep_version = "5"
+    prep_version = "6"
     resources = module + "_resources"
 
 

--- a/scenarios/macos/mac_mlperf/mac_mlperf_resources/mac_mlperf_run.sh
+++ b/scenarios/macos/mac_mlperf/mac_mlperf_resources/mac_mlperf_run.sh
@@ -75,7 +75,7 @@ log "   Command: $MLPERF_EXE --config $CONFIG_FILE --temp-dir . --output-dir $OU
 
 # Redirect output to a per-phase log so it is preserved in the results share.
 # Without redirection, stdout goes only to the RPC buffer and is lost on timeout.
-MLPERF_LOG="$LOG_DIR/mac_mlperf_run_output.log"
+MLPERF_LOG="$OUTPUT_DIR/mac_mlperf_run_output.log"
 log "-- MLPerf output: $MLPERF_LOG"
 "$MLPERF_EXE" --config "$CONFIG_FILE" --temp-dir . --output-dir "$OUTPUT_DIR" --download_behaviour skip_all --pause false > "$MLPERF_LOG" 2>&1
 

--- a/scenarios/macos/mac_mlperf/mac_mlperf_resources/mac_mlperf_run.sh
+++ b/scenarios/macos/mac_mlperf/mac_mlperf_resources/mac_mlperf_run.sh
@@ -73,11 +73,15 @@ fi
 log "-- Running MLPerf benchmark..."
 log "   Command: $MLPERF_EXE --config $CONFIG_FILE --temp-dir . --output-dir $OUTPUT_DIR --download_behaviour skip_all --pause false"
 
-"$MLPERF_EXE" --config "$CONFIG_FILE" --temp-dir . --output-dir "$OUTPUT_DIR" --download_behaviour skip_all --pause false
+# Redirect output to a per-phase log so it is preserved in the results share.
+# Without redirection, stdout goes only to the RPC buffer and is lost on timeout.
+MLPERF_LOG="$LOG_DIR/mac_mlperf_run_output.log"
+log "-- MLPerf output: $MLPERF_LOG"
+"$MLPERF_EXE" --config "$CONFIG_FILE" --temp-dir . --output-dir "$OUTPUT_DIR" --download_behaviour skip_all --pause false > "$MLPERF_LOG" 2>&1
 
 EXIT_CODE=$?
 if [ $EXIT_CODE -ne 0 ]; then
-    log " ERROR - MLPerf benchmark failed with exit code: $EXIT_CODE"
+    log " ERROR - MLPerf benchmark failed with exit code: $EXIT_CODE. See $MLPERF_LOG for details."
     exit $EXIT_CODE
 fi
 

--- a/scenarios/macos/mac_net_aspire/mac_net_aspire.py
+++ b/scenarios/macos/mac_net_aspire/mac_net_aspire.py
@@ -14,7 +14,7 @@ import time
 class MacNetAspire(core.app_scenario.Scenario):
 
     module = __module__.split('.')[-1]
-    prep_version = "8"
+    prep_version = "9"
     resources = module + "_resources"
 
 

--- a/scenarios/macos/mac_net_aspire/mac_net_aspire_resources/mac_net_aspire_run.sh
+++ b/scenarios/macos/mac_net_aspire/mac_net_aspire_resources/mac_net_aspire_run.sh
@@ -150,7 +150,11 @@ log "-- net_aspire restore ended"
 # ============================================================================
 log "-- net_aspire build started"
 
-/usr/bin/time -p -o "$LOG_DIR/mac_net_aspire_build_time.log" ./build.sh --build
+# Redirect output to a per-phase log so it is preserved in the results share.
+# Without redirection, stdout goes only to the RPC buffer and is lost on timeout.
+BUILD_LOG="$LOG_DIR/mac_net_aspire_build.log"
+log "-- Build output: $BUILD_LOG"
+/usr/bin/time -p -o "$LOG_DIR/mac_net_aspire_build_time.log" ./build.sh --build > "$BUILD_LOG" 2>&1
 check_status "Building .NET Aspire"
 
 # Parse build phase timing

--- a/scenarios/macos/mac_nodejs/mac_nodejs.py
+++ b/scenarios/macos/mac_nodejs/mac_nodejs.py
@@ -14,7 +14,7 @@ import time
 class MacNodejs(core.app_scenario.Scenario):
 
     module = __module__.split('.')[-1]
-    prep_version = "4"
+    prep_version = "5"
     resources = module + "_resources"
 
 

--- a/scenarios/macos/mac_nodejs/mac_nodejs_resources/mac_nodejs_run.sh
+++ b/scenarios/macos/mac_nodejs/mac_nodejs_resources/mac_nodejs_run.sh
@@ -155,7 +155,13 @@ log "-- Starting Node.js compilation"
 CORES=$(sysctl -n hw.ncpu)
 log "Building with $CORES cores"
 
-/usr/bin/time -p -o "$LOG_DIR/mac_nodejs_build_time.log" make -j$CORES
+# Redirect make output to a per-phase log so it is preserved in the results
+# share. Without redirection, stdout goes only to the RPC buffer and is lost
+# on timeout.
+BUILD_LOG="$LOG_DIR/mac_nodejs_build.log"
+log "-- Build output: $BUILD_LOG"
+
+/usr/bin/time -p -o "$LOG_DIR/mac_nodejs_build_time.log" make -j$CORES > "$BUILD_LOG" 2>&1
 check_status "Node.js build"
 
 # Parse build phase timing

--- a/scenarios/macos/mac_opencv_build/mac_opencv_build.py
+++ b/scenarios/macos/mac_opencv_build/mac_opencv_build.py
@@ -14,7 +14,7 @@ import time
 class MacOpencvBuild(core.app_scenario.Scenario):
 
     module = __module__.split('.')[-1]
-    prep_version = "4"
+    prep_version = "5"
     resources = module + "_resources"
 
 

--- a/scenarios/macos/mac_opencv_build/mac_opencv_build_resources/mac_opencv_build_run.sh
+++ b/scenarios/macos/mac_opencv_build/mac_opencv_build_resources/mac_opencv_build_run.sh
@@ -135,7 +135,13 @@ log "-- Starting OpenCV build"
 CORES=$(sysctl -n hw.ncpu)
 log "Building with $CORES cores"
 
-/usr/bin/time -p -o "$LOG_DIR/mac_opencv_build_time.log" make -j$CORES
+# Redirect make output to a per-phase log so it is preserved in the results
+# share. Without redirection, stdout goes only to the RPC buffer and is lost
+# on timeout.
+BUILD_LOG="$LOG_DIR/mac_opencv_build.log"
+log "-- Build output: $BUILD_LOG"
+
+/usr/bin/time -p -o "$LOG_DIR/mac_opencv_build_time.log" make -j$CORES > "$BUILD_LOG" 2>&1
 check_status "OpenCV build"
 
 # Parse build phase timing

--- a/scenarios/macos/mac_spring_petclinic/mac_spring_petclinic.py
+++ b/scenarios/macos/mac_spring_petclinic/mac_spring_petclinic.py
@@ -14,7 +14,7 @@ import time
 class MacSpringPetClinic(core.app_scenario.Scenario):
 
     module = __module__.split('.')[-1]
-    prep_version = "8"
+    prep_version = "9"
     resources = module + "_resources"
 
 

--- a/scenarios/macos/mac_spring_petclinic/mac_spring_petclinic_resources/mac_spring_petclinic_run.sh
+++ b/scenarios/macos/mac_spring_petclinic/mac_spring_petclinic_resources/mac_spring_petclinic_run.sh
@@ -129,12 +129,19 @@ fi
 log "✓ Maven wrapper found"
 
 log "-- Cleaning previous build"
-./mvnw -Dmaven.repo.local=$BIN_DIR/m2-spring-petclinic clean
+# Redirect Maven output to a per-phase log under hobl_data so it is preserved
+# in the results share. Without redirection, stdout goes only to the RPC
+# buffer and is lost on RPC timeout.
+MAVEN_CLEAN_LOG="$LOG_DIR/mac_spring_petclinic_maven_clean.log"
+log "-- Maven clean output: $MAVEN_CLEAN_LOG"
+./mvnw -Dmaven.repo.local=$BIN_DIR/m2-spring-petclinic clean > "$MAVEN_CLEAN_LOG" 2>&1
 check_status "Maven clean"
 
 log "-- spring_petclinic build started"
 
-/usr/bin/time -p -o "$LOG_DIR/mac_spring_petclinic_build_time.log" ./mvnw -o -Dmaven.repo.local=$BIN_DIR/m2-spring-petclinic -DskipTests package
+MAVEN_BUILD_LOG="$LOG_DIR/mac_spring_petclinic_maven_build.log"
+log "-- Maven build output: $MAVEN_BUILD_LOG"
+/usr/bin/time -p -o "$LOG_DIR/mac_spring_petclinic_build_time.log" ./mvnw -o -Dmaven.repo.local=$BIN_DIR/m2-spring-petclinic -DskipTests package > "$MAVEN_BUILD_LOG" 2>&1
 check_status "Maven package (build)"
 
 # Parse build phase timing
@@ -144,7 +151,9 @@ log "-- spring_petclinic build ended"
 
 log "-- spring_petclinic tests started"
 
-/usr/bin/time -p -o "$LOG_DIR/mac_spring_petclinic_test_time.log" ./mvnw -o -Dmaven.repo.local=$BIN_DIR/m2-spring-petclinic test
+MAVEN_TEST_LOG="$LOG_DIR/mac_spring_petclinic_maven_test.log"
+log "-- Maven test output: $MAVEN_TEST_LOG"
+/usr/bin/time -p -o "$LOG_DIR/mac_spring_petclinic_test_time.log" ./mvnw -o -Dmaven.repo.local=$BIN_DIR/m2-spring-petclinic test > "$MAVEN_TEST_LOG" 2>&1
 check_status "Maven test"
 
 # Parse test phase timing

--- a/scenarios/macos/mac_vscode/mac_vscode.py
+++ b/scenarios/macos/mac_vscode/mac_vscode.py
@@ -14,7 +14,7 @@ import time
 class MacVscode(scenarios.app_scenario.Scenario):
 
     module = __module__.split('.')[-1]
-    prep_version = "7"
+    prep_version = "8"
     resources = module + "_resources"
 
 

--- a/scenarios/macos/mac_vscode/mac_vscode.py
+++ b/scenarios/macos/mac_vscode/mac_vscode.py
@@ -14,7 +14,7 @@ import time
 class MacVscode(scenarios.app_scenario.Scenario):
 
     module = __module__.split('.')[-1]
-    prep_version = "6"
+    prep_version = "7"
     resources = module + "_resources"
 
 

--- a/scenarios/macos/mac_vscode/mac_vscode_resources/mac_vscode_prep.sh
+++ b/scenarios/macos/mac_vscode/mac_vscode_resources/mac_vscode_prep.sh
@@ -122,17 +122,17 @@ fi
 source ~/.zprofile
 check_command "pyenv" || exit 1
 
-log "-- Installing Python 3.10.11"
-pyenv install 3.10.11 -f
-check_status "Python 3.10.11 installation"
+log "-- Installing Python 3.12.10"
+pyenv install 3.12.10 -f
+check_status "Python 3.12.10 installation"
 
 log "-- Setting Python version"
-pyenv global 3.10.11
+pyenv global 3.12.10
 check_status "Setting Python global version"
 
 PYTHON_VERSION=$(python --version 2>&1 | awk '{print $2}')
-if [ "$PYTHON_VERSION" != "3.10.11" ]; then
-    log " ERROR - Python version is $PYTHON_VERSION, expected 3.10.11"
+if [ "$PYTHON_VERSION" != "3.12.10" ]; then
+    log " ERROR - Python version is $PYTHON_VERSION, expected 3.12.10"
     pyenv versions
     exit 1
 fi

--- a/scenarios/macos/mac_vscode/mac_vscode_resources/mac_vscode_run.sh
+++ b/scenarios/macos/mac_vscode/mac_vscode_resources/mac_vscode_run.sh
@@ -118,7 +118,13 @@ log "✓ Cleaned .build and out directories"
 # Build VS Code
 log "-- Starting VS Code compilation"
 
-/usr/bin/time -p -o "$LOG_DIR/mac_vscode_build_time.log" npm run compile
+# Redirect npm output to a per-phase log so it is preserved in the results
+# share. Without redirection, stdout goes only to the RPC buffer and is lost
+# on timeout.
+BUILD_LOG="$LOG_DIR/mac_vscode_build.log"
+log "-- Build output: $BUILD_LOG"
+
+/usr/bin/time -p -o "$LOG_DIR/mac_vscode_build_time.log" npm run compile > "$BUILD_LOG" 2>&1
 check_status "VS Code build"
 
 parse_time_output "$LOG_DIR/mac_vscode_build_time.log" "build"

--- a/scenarios/windows/fast_api/fast_api.py
+++ b/scenarios/windows/fast_api/fast_api.py
@@ -14,7 +14,7 @@ from datetime import datetime
 class FastApi(core.app_scenario.Scenario):
 
     module = __module__.split('.')[-1]
-    prep_version = "7"
+    prep_version = "8"
     resources = module + "_resources"
 
 

--- a/scenarios/windows/fast_api/fast_api.py
+++ b/scenarios/windows/fast_api/fast_api.py
@@ -14,7 +14,7 @@ from datetime import datetime
 class FastApi(core.app_scenario.Scenario):
 
     module = __module__.split('.')[-1]
-    prep_version = "5"
+    prep_version = "6"
     resources = module + "_resources"
 
 

--- a/scenarios/windows/fast_api/fast_api.py
+++ b/scenarios/windows/fast_api/fast_api.py
@@ -14,7 +14,7 @@ from datetime import datetime
 class FastApi(core.app_scenario.Scenario):
 
     module = __module__.split('.')[-1]
-    prep_version = "6"
+    prep_version = "7"
     resources = module + "_resources"
 
 

--- a/scenarios/windows/fast_api/fast_api_resources/fast_api_prep.ps1
+++ b/scenarios/windows/fast_api/fast_api_resources/fast_api_prep.ps1
@@ -765,10 +765,19 @@ Set-OptimizedPathOrder
 "Current session PATH contains System32: $($env:PATH -like "*System32*")" | log
 "Current session PATH contains WindowsApps: $($env:PATH -like "*WindowsApps*")" | log
 
+# --- Install Python via pyenv (conditional — DO NOT use -f) ---
+# Force-reinstall (`-f`) wipes the pyenv version directory including any packages
+# installed by other scenarios that share this Python version. We only install
+# when the version is truly missing.
 "-- Installing python $pythonVersion for $logSuffix" | log
-"Installing Python $pythonVersion (this may take several minutes)..." | log
-pyenv install $pythonVersion -f
-check($lastexitcode)
+$installedVersions = (pyenv versions --bare 2>$null) -split "`n" | ForEach-Object { $_.Trim() }
+if ($installedVersions -notcontains $pythonVersion) {
+    "Installing Python $pythonVersion via pyenv (this may take several minutes)..." | log
+    pyenv install $pythonVersion
+    check($lastexitcode)
+} else {
+    "Python $pythonVersion already installed via pyenv — preserving existing install" | log
+}
 
 "Setting Python $pythonVersion as global version..." | log
 pyenv global $pythonVersion
@@ -841,16 +850,45 @@ if ($currentPythonVersion -like "*$expectedVersionPattern*") {
     Exit 1
 }
 
-"Checking pip Version"
-$pipVersion = pip --version
-"pip version: $pipVersion" | log
+# --- Create per-scenario venv ---
+# Packages live in this scenario's private venv directory, NOT in the shared pyenv
+# site-packages. This isolates fast_api's packages from any future `pyenv install`
+# (force or otherwise) from other scenarios, and from `pyenv global` switches.
+$venvDir = "$scriptDrive\hobl_bin\fast_api_resources\.venv"
+$pyenvPythonRaw = (pyenv which python 2>$null)
+if (-not $pyenvPythonRaw) {
+    " ERROR - pyenv which python returned no path; pyenv install may have failed" | log
+    Exit 1
+}
+$pyenvPython = $pyenvPythonRaw.Trim()
+if (-not (Test-Path $pyenvPython)) {
+    " ERROR - pyenv python not found at: $pyenvPython" | log
+    Exit 1
+}
+"Base pyenv python: $pyenvPython" | log
 
-"Installing requirements.txt..." | log
-pip install -r requirements.txt
+if (Test-Path $venvDir) {
+    "Removing existing venv to ensure clean rebuild: $venvDir" | log
+    Remove-Item -Recurse -Force $venvDir
+}
+"Creating venv at: $venvDir" | log
+& $pyenvPython -m venv $venvDir
 check($lastexitcode)
 
-"Installing build tools..." | log
-pip install build
+$venvPython = Join-Path $venvDir "Scripts\python.exe"
+$venvPip = Join-Path $venvDir "Scripts\pip.exe"
+if (-not (Test-Path $venvPython)) {
+    " ERROR - venv python missing after venv creation: $venvPython" | log
+    Exit 1
+}
+"Venv python: $venvPython" | log
+
+"Installing requirements.txt into venv..." | log
+& $venvPip install -r requirements.txt
+check($lastexitcode)
+
+"Installing build tool into venv..." | log
+& $venvPip install build
 check($lastexitcode)
 
 "-- FastAPI prep completed ($logSuffix version)" | log

--- a/scenarios/windows/fast_api/fast_api_resources/fast_api_prep.ps1
+++ b/scenarios/windows/fast_api/fast_api_resources/fast_api_prep.ps1
@@ -41,7 +41,7 @@ $processorArch = $env:PROCESSOR_ARCHITECTURE
 if ($arch -eq "64-bit" -and $processorArch -eq "AMD64") {
     $isARM64 = $false
     $logSuffix = "x64"
-    $pythonVersion = "3.11.9"
+    $pythonVersion = "3.12.10"
     $vsArchParam = "x64"
     $vsHostArchParam = "x64"
     $vsInstallPath = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\2022"
@@ -49,7 +49,7 @@ if ($arch -eq "64-bit" -and $processorArch -eq "AMD64") {
 } elseif ($arch -match "ARM" -or $processorArch -match "ARM") {
     $isARM64 = $true
     $logSuffix = "ARM64"
-    $pythonVersion = "3.11.9-arm"
+    $pythonVersion = "3.12.10-arm"
     $vsArchParam = "arm64"
     $vsHostArchParam = "arm64"
     $vsInstallPath = "${env:ProgramFiles}\Microsoft Visual Studio\2022"

--- a/scenarios/windows/fast_api/fast_api_resources/fast_api_run.ps1
+++ b/scenarios/windows/fast_api/fast_api_resources/fast_api_run.ps1
@@ -304,101 +304,35 @@ if ($LASTEXITCODE -ne 0) {
     Exit 1
 }
 
-"Current Python version:" | log
-pyenv version
-
-"Location of python:" | log
-pyenv which python
-
-"Location of python3:" | log
-pyenv which python3
-
-"Dump environment variables:" | log
-Get-ChildItem Env:
-
-# Comprehensive Python detection function
-function Find-AllPython {
-    "=== Python Detection Report ===" | log
-    
-    # Check PATH
-    "`n1. Python in PATH:" | log
-    try {
-        $pathPython = Get-Command python -ErrorAction SilentlyContinue
-        if ($pathPython) {
-            "  Found: $($pathPython.Source)" | log
-            & python --version 2>&1
-        } else {
-            "  No python in PATH" | log
-        }
-    } catch {
-        "  No python in PATH" | log
-    }
-    
-    # Check file system
-    "`n2. Python installations on disk:" | log
-    $searchPaths = @(
-        "${env:ProgramFiles}\Python*",
-        "${env:ProgramFiles(x86)}\Python*",
-        "${env:LOCALAPPDATA}\Programs\Python\Python*",
-        "${env:APPDATA}\Python\Python*"
-    )
-    
-    foreach ($path in $searchPaths) {
-        $found = Get-ChildItem $path -ErrorAction SilentlyContinue
-        foreach ($dir in $found) {
-            $pythonExe = Join-Path $dir.FullName "python.exe"
-            if (Test-Path $pythonExe) {
-                "  Found: $pythonExe" | log
-                try {
-                    & $pythonExe --version 2>&1
-                } catch {}
-            }
-        }
-    }
-    
-    # Check Windows Store
-    "`n3. Windows Store Python:" | log
-    $storePython = "${env:LOCALAPPDATA}\Microsoft\WindowsApps\python.exe"
-    if (Test-Path $storePython) {
-        "  Found: $storePython" | log
-        & $storePython --version 2>&1
-    } else {
-        "  Not installed" | log
-    }
-    
-    # Check pyenv
-    "`n4. pyenv-win managed Python:" | log
-    if (Get-Command pyenv -ErrorAction SilentlyContinue) {
-        "  pyenv is available" | log
-        pyenv versions
-    } else {
-        "  pyenv not found" | log
-    }
+# --- Validate per-scenario venv and required packages ---
+# Prep stages all Python packages into a private venv under this scenario's
+# resource directory. We invoke that venv's python.exe by absolute path to
+# bypass any pyenv/PATH instability caused by other scenarios. If the venv
+# is missing or an expected package is not importable, we fail fast with a
+# clear diagnostic instead of cryptic errors mid-build.
+$venvPython = "$scriptDrive\hobl_bin\fast_api_resources\.venv\Scripts\python.exe"
+if (-not (Test-Path $venvPython)) {
+    " ERROR - fast_api venv missing at $venvPython" | log
+    " ERROR - Prep state is corrupt. Re-prep required:" | log
+    " ERROR -   delete C:\hobl_bin\prep_status\fast_api<version> on the DUT and re-run." | log
+    Exit 1
 }
+"Using venv python: $venvPython" | log
 
-# Run the detection
-Find-AllPython
-
-# Verify pyenv Python is being used
-"`n=== Python Resolution Verification ===" | log
-$whichPython = Get-Command python -ErrorAction SilentlyContinue
-if ($whichPython) {
-    "Resolved python.exe: $($whichPython.Source)" | log
-        if ($whichPython.Source -like "*pyenv*") {
-        "SUCCESS: pyenv Python is being used" | log
-    } else {
-        "WARNING: Non-pyenv Python is being used" | log
-        "This may cause version conflicts" | log
-    }
-    } else {
-    " ERROR - No python found in PATH" | log
+"Validating venv has build tool..." | log
+& $venvPython -c "import build; print('build', build.__version__)" 2>&1 | log
+if ($LASTEXITCODE -ne 0) {
+    " ERROR - venv has missing/broken 'build' package." | log
+    " ERROR - Possible causes: Defender quarantine, disk cleanup, or external tampering." | log
+    " ERROR - Re-prep required: delete C:\hobl_bin\prep_status\fast_api<version> on the DUT and re-run." | log
+    Exit 1
 }
 
 "Building FastAPI..." | log
 Write-RunPhaseMarker "phase.run_prep.end"
 Write-RunPhaseMarker "phase.run_build.start"
 $buildTime = (Measure-Command {
-    python -m build
+    & $venvPython -m build
 }).TotalSeconds
 $buildExitCode = $LASTEXITCODE
 Write-RunPhaseMarker "phase.run_build.end"

--- a/scenarios/windows/fast_api/fast_api_resources/fast_api_run.ps1
+++ b/scenarios/windows/fast_api/fast_api_resources/fast_api_run.ps1
@@ -331,13 +331,18 @@ if ($LASTEXITCODE -ne 0) {
 "Building FastAPI..." | log
 Write-RunPhaseMarker "phase.run_prep.end"
 Write-RunPhaseMarker "phase.run_build.start"
+# Redirect output to a per-phase log so it is preserved in the results share.
+# Measure-Command discards pipeline output, and the RPC buffer is lost on timeout,
+# so file redirection is the only way to capture build/test output.
+$buildLog = "$LOG_DIR\fast_api_build.log"
+"Build output: $buildLog" | log
 $buildTime = (Measure-Command {
-    & $venvPython -m build
+    & $venvPython -m build *> $buildLog
 }).TotalSeconds
 $buildExitCode = $LASTEXITCODE
 Write-RunPhaseMarker "phase.run_build.end"
 if ($buildExitCode -ne 0) {
-    " ERROR - Build failed" | log
+    " ERROR - Build failed. See $buildLog for details." | log
     Exit 1
 }
 $buildTime = [math]::Round($buildTime, 2)
@@ -349,8 +354,10 @@ $env:PYTHONIOENCODING = "utf-8"
 
 "Running tests with coverage..." | log
 Write-RunPhaseMarker "phase.run_test.start"
+$testLog = "$LOG_DIR\fast_api_test.log"
+"Test output: $testLog" | log
 $testTime = (Measure-Command {
-    coverage run -m pytest tests
+    coverage run -m pytest tests *> $testLog
 }).TotalSeconds
 $testExitCode = $LASTEXITCODE
 Write-RunPhaseMarker "phase.run_test.end"

--- a/scenarios/windows/fast_api/fast_api_resources/fast_api_run.ps1
+++ b/scenarios/windows/fast_api/fast_api_resources/fast_api_run.ps1
@@ -319,10 +319,10 @@ if (-not (Test-Path $venvPython)) {
 }
 "Using venv python: $venvPython" | log
 
-"Validating venv has build tool..." | log
-& $venvPython -c "import build; print('build', build.__version__)" 2>&1 | log
+"Validating venv has required packages..." | log
+& $venvPython -c "import build, coverage, pytest; print('build', build.__version__, '| coverage', coverage.__version__, '| pytest', pytest.__version__)" 2>&1 | log
 if ($LASTEXITCODE -ne 0) {
-    " ERROR - venv has missing/broken 'build' package." | log
+    " ERROR - venv has missing/broken Python packages (build, coverage, pytest expected)." | log
     " ERROR - Possible causes: Defender quarantine, disk cleanup, or external tampering." | log
     " ERROR - Re-prep required: delete C:\hobl_bin\prep_status\fast_api<version> on the DUT and re-run." | log
     Exit 1
@@ -356,8 +356,11 @@ $env:PYTHONIOENCODING = "utf-8"
 Write-RunPhaseMarker "phase.run_test.start"
 $testLog = "$LOG_DIR\fast_api_test.log"
 "Test output: $testLog" | log
+# Invoke coverage via the venv's python so it resolves to the venv-installed
+# coverage package (installed via requirements-tests.txt). A bare `coverage`
+# would go through PATH lookup and either fail or hit a different Python.
 $testTime = (Measure-Command {
-    coverage run -m pytest tests *> $testLog
+    & $venvPython -m coverage run -m pytest tests *> $testLog
 }).TotalSeconds
 $testExitCode = $LASTEXITCODE
 Write-RunPhaseMarker "phase.run_test.end"

--- a/scenarios/windows/fast_api/fast_api_resources/fast_api_run.ps1
+++ b/scenarios/windows/fast_api/fast_api_resources/fast_api_run.ps1
@@ -66,10 +66,10 @@ $arch = $osInfo.OSArchitecture
 $processorArch = $env:PROCESSOR_ARCHITECTURE
 
 if ($arch -eq "64-bit" -and $processorArch -eq "AMD64") {
-    $pythonVersion = "3.11.9"
+    $pythonVersion = "3.12.10"
     $logSuffix = "x64"
 } elseif ($arch -match "ARM" -or $processorArch -match "ARM") {
-    $pythonVersion = "3.11.9-arm"
+    $pythonVersion = "3.12.10-arm"
     $logSuffix = "ARM64"
 } else {
     Write-Host " ERROR - Unsupported architecture: $arch (Processor: $processorArch)" -ForegroundColor Red

--- a/scenarios/windows/llvm/llvm.py
+++ b/scenarios/windows/llvm/llvm.py
@@ -14,7 +14,7 @@ from datetime import datetime
 class Llvm(scenarios.app_scenario.Scenario):
 
     module = __module__.split('.')[-1]
-    prep_version = "8"
+    prep_version = "9"
     resources = module + "_resources"
 
 

--- a/scenarios/windows/llvm/llvm_resources/llvm_prep.ps1
+++ b/scenarios/windows/llvm/llvm_resources/llvm_prep.ps1
@@ -520,10 +520,19 @@ Set-OptimizedPathOrder
 "Current session PATH contains System32: $($env:PATH -like "*System32*")" | log
 "Current session PATH contains WindowsApps: $($env:PATH -like "*WindowsApps*")" | log
 
+# --- Install Python via pyenv (conditional — DO NOT use -f) ---
+# Force-reinstall (`-f`) wipes the pyenv version directory including any packages
+# installed by other scenarios that share this Python version. We only install
+# when the version is truly missing.
 "-- Installing python $pythonVersion for $logSuffix" | log
-"Installing Python $pythonVersion (this may take several minutes)..." | log
-pyenv install $pythonVersion -f
-check($lastexitcode)
+$installedVersions = (pyenv versions --bare 2>$null) -split "`n" | ForEach-Object { $_.Trim() }
+if ($installedVersions -notcontains $pythonVersion) {
+    "Installing Python $pythonVersion via pyenv (this may take several minutes)..." | log
+    pyenv install $pythonVersion
+    check($lastexitcode)
+} else {
+    "Python $pythonVersion already installed via pyenv — preserving existing install" | log
+}
 
 "Setting Python $pythonVersion as global version..." | log
 pyenv global $pythonVersion

--- a/scenarios/windows/nodejs/nodejs.py
+++ b/scenarios/windows/nodejs/nodejs.py
@@ -14,7 +14,7 @@ from datetime import datetime
 class Nodejs(core.app_scenario.Scenario):
 
     module = __module__.split('.')[-1]
-    prep_version = "7"
+    prep_version = "8"
     resources = module + "_resources"
 
 

--- a/scenarios/windows/nodejs/nodejs_resources/nodejs_prep.ps1
+++ b/scenarios/windows/nodejs/nodejs_resources/nodejs_prep.ps1
@@ -475,8 +475,19 @@ Expand-Archive -Path .\nodejs.zip -DestinationPath .\nodejs -Force
 Invoke-WebRequest -UseBasicParsing -Uri "https://raw.githubusercontent.com/pyenv-win/pyenv-win/master/pyenv-win/install-pyenv-win.ps1" -OutFile "./install-pyenv-win.ps1"; &"./install-pyenv-win.ps1"
 $Env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
 
+# --- Install Python via pyenv (conditional — DO NOT use -f) ---
+# Force-reinstall (`-f`) wipes the pyenv version directory including any packages
+# installed by other scenarios that share this Python version. We only install
+# when the version is truly missing. Node.js only needs the interpreter (for
+# node-gyp / vcbuild.bat) so no venv is required.
 "-- Installing python $pythonVersion" | log
-pyenv install $pythonVersion -f
+$installedVersions = (pyenv versions --bare 2>$null) -split "`n" | ForEach-Object { $_.Trim() }
+if ($installedVersions -notcontains $pythonVersion) {
+    "Installing Python $pythonVersion via pyenv..." | log
+    pyenv install $pythonVersion
+} else {
+    "Python $pythonVersion already installed via pyenv — preserving existing install" | log
+}
 pyenv versions; pyenv global $pythonVersion; pyenv versions
 
 

--- a/scenarios/windows/opencv_build/opencv_build.py
+++ b/scenarios/windows/opencv_build/opencv_build.py
@@ -13,7 +13,7 @@ from datetime import datetime
 class OpencvBuild(core.app_scenario.Scenario):
 
     module = __module__.split('.')[-1]
-    prep_version = "6"
+    prep_version = "7"
     resources = module + "_resources"
 
 

--- a/scenarios/windows/opencv_build/opencv_build_resources/opencv_build_run.ps1
+++ b/scenarios/windows/opencv_build/opencv_build_resources/opencv_build_run.ps1
@@ -122,18 +122,30 @@ if (-not (Test-Path "$scriptDrive\opencv\build_msvc")) {
 }
 
 Set-Location "$scriptDrive\opencv\build_msvc"
-cmake --build . --target clean --config Release
+# Redirect cmake output to per-phase logs preserved in hobl_data. Without
+# redirection, stdout goes only to the RPC buffer (lost on timeout); inside
+# Measure-Command, stdout is silently discarded entirely.
+$logDir = Split-Path $logFile -Parent
+$cleanLog = "$logDir\opencv_build_clean.log"
+$buildLog = "$logDir\opencv_build_build.log"
+$installLog = "$logDir\opencv_build_install.log"
+"Clean output: $cleanLog" | log
+cmake --build . --target clean --config Release *> $cleanLog
 check($lastexitcode)
 
 $time = Get-Date -Format "HH:mm:ss"
 "$time - Build OpenCV Project" | log
+"Build output: $buildLog" | log
 Write-RunPhaseMarker "phase.run_prep.end"
 Write-RunPhaseMarker "phase.run_build.start"
 
 $buildDuration = Measure-Command {
-    cmake --build . --config Release
+    cmake --build . --config Release *> $buildLog
 }
-check($lastexitcode)
+if ($lastexitcode -ne 0) {
+    " ERROR - cmake build failed. See $buildLog for details." | log
+    Exit 1
+}
 
 $buildTime = [math]::Round($buildDuration.TotalSeconds, 2)
 $scenarioRuntime = $buildTime
@@ -145,8 +157,12 @@ $time = Get-Date -Format "HH:mm:ss"
 
 $time = Get-Date -Format "HH:mm:ss"
 "$time - Build OpenCV Install Project" | log
-cmake --build . --target INSTALL --config Release
-check($lastexitcode)
+"Install output: $installLog" | log
+cmake --build . --target INSTALL --config Release *> $installLog
+if ($lastexitcode -ne 0) {
+    " ERROR - cmake INSTALL failed. See $installLog for details." | log
+    Exit 1
+}
 
 $time = Get-Date -Format "HH:mm:ss"
 "$time - OpenCV completed building" | log

--- a/scenarios/windows/pytorch_inf/pytorch_inf.py
+++ b/scenarios/windows/pytorch_inf/pytorch_inf.py
@@ -14,7 +14,7 @@ from datetime import datetime
 class PytorchInf(core.app_scenario.Scenario):
 
     module = __module__.split('.')[-1]
-    prep_version = "13"
+    prep_version = "14"
     # prep_scenarios = [(module, prep_version)]
     resources = module + "_resources"
 

--- a/scenarios/windows/pytorch_inf/pytorch_inf_resources/pytorch_inf_prep.ps1
+++ b/scenarios/windows/pytorch_inf/pytorch_inf_resources/pytorch_inf_prep.ps1
@@ -504,11 +504,19 @@ function Set-OptimizedPathOrder {
 
 Set-OptimizedPathOrder
 
-# --- Install Python via pyenv ---
+# --- Install Python via pyenv (conditional — DO NOT use -f) ---
+# Force-reinstall (`-f`) wipes the pyenv version directory including any packages
+# installed by other scenarios that share this Python version. Multiple scenarios
+# use 3.12.10-arm, so we only install when truly missing.
 "-- Installing python $pythonVersion for $logSuffix" | log
-"Installing Python $pythonVersion (this may take several minutes)..." | log
-pyenv install $pythonVersion -f
-check($lastexitcode)
+$installedVersions = (pyenv versions --bare 2>$null) -split "`n" | ForEach-Object { $_.Trim() }
+if ($installedVersions -notcontains $pythonVersion) {
+    "Installing Python $pythonVersion via pyenv (this may take several minutes)..." | log
+    pyenv install $pythonVersion
+    check($lastexitcode)
+} else {
+    "Python $pythonVersion already installed via pyenv — preserving existing install" | log
+}
 
 "Setting Python $pythonVersion as global version..." | log
 pyenv global $pythonVersion
@@ -585,9 +593,42 @@ if ($currentPythonVersion -like "*$expectedVersionPattern*") {
     Exit 1
 }
 
+# --- Create per-scenario venv ---
+# Packages live in this scenario's private venv directory, NOT in the shared pyenv
+# site-packages. This isolates pytorch_inf's packages from any future `pyenv install`
+# (force or otherwise) from other scenarios, and from `pyenv global` switches.
+$venvDir = "$scriptDrive\hobl_bin\pytorch_inf_resources\.venv"
+$pyenvPythonRaw = (pyenv which python 2>$null)
+if (-not $pyenvPythonRaw) {
+    " ERROR - pyenv which python returned no path; pyenv install may have failed" | log
+    Exit 1
+}
+$pyenvPython = $pyenvPythonRaw.Trim()
+if (-not (Test-Path $pyenvPython)) {
+    " ERROR - pyenv python not found at: $pyenvPython" | log
+    Exit 1
+}
+"Base pyenv python: $pyenvPython" | log
+
+if (Test-Path $venvDir) {
+    "Removing existing venv to ensure clean rebuild: $venvDir" | log
+    Remove-Item -Recurse -Force $venvDir
+}
+"Creating venv at: $venvDir" | log
+& $pyenvPython -m venv $venvDir
+check($lastexitcode)
+
+$venvPython = Join-Path $venvDir "Scripts\python.exe"
+$venvPip = Join-Path $venvDir "Scripts\pip.exe"
+if (-not (Test-Path $venvPython)) {
+    " ERROR - venv python missing after venv creation: $venvPython" | log
+    Exit 1
+}
+"Venv python: $venvPython" | log
+
 if ($useCustomPyTorchWheel) {
     # --- Custom wheel path: install custom PyTorch wheel + remaining deps ---
-    "-- Installing PyTorch from custom wheel" | log
+    "-- Installing PyTorch from custom wheel into venv" | log
     if (-not $customResourcesPath -or -not (Test-Path $customResourcesPath)) {
         " ERROR - Custom resources path required for custom wheel install: $customResourcesPath" | log
         Exit 1
@@ -599,22 +640,22 @@ if ($useCustomPyTorchWheel) {
         Exit 1
     }
     "Found wheel: $($wheelFile.Name) ($([math]::Round($wheelFile.Length / 1MB, 1)) MB)" | log
-    pip install $wheelFile.FullName
+    & $venvPip install $wheelFile.FullName
     check($lastexitcode)
-    "-- Installing remaining dependencies from requirements_custom.txt" | log
-    pip install -r requirements_custom.txt
+    "-- Installing remaining dependencies from requirements_custom.txt into venv" | log
+    & $venvPip install -r requirements_custom.txt
     check($lastexitcode)
 } else {
     # --- Standard path: x64 (cu128) or Arm64 CPU ---
     $requirementsFile = if ($isARM64) { "requirements_win_arm64.txt" } else { "requirements_win.txt" }
-    "-- Installing Python packages from $requirementsFile" | log
-    pip install -r $requirementsFile
+    "-- Installing Python packages from $requirementsFile into venv" | log
+    & $venvPip install -r $requirementsFile
     check($lastexitcode)
 }
 
-# --- Download model ---
+# --- Download model (using venv python so torch is available) ---
 "-- Setup LLM Phi-4-mini inferencing" | log
-python inference.py --setup
+& $venvPython inference.py --setup
 check($lastexitcode)
 
 "-- pytorch_inf prep completed ($logSuffix version)" | log

--- a/scenarios/windows/pytorch_inf/pytorch_inf_resources/pytorch_inf_run.ps1
+++ b/scenarios/windows/pytorch_inf/pytorch_inf_resources/pytorch_inf_run.ps1
@@ -272,6 +272,32 @@ pyenv which python
 Set-Location "$scriptDrive\hobl_bin\pytorch_inf_resources"
 checkCmd($?)
 
+# --- Validate per-scenario venv and required imports ---
+# Prep stages all Python packages into a private venv under this scenario's
+# resource directory. We invoke that venv's python.exe by absolute path to
+# bypass any pyenv/PATH instability caused by other scenarios. If the venv
+# is missing or an expected package is not importable (e.g. an external tool
+# quarantined a DLL), we fail fast with a clear diagnostic instead of a
+# cryptic ModuleNotFoundError partway through the workload.
+$venvPython = "$scriptDrive\hobl_bin\pytorch_inf_resources\.venv\Scripts\python.exe"
+if (-not (Test-Path $venvPython)) {
+    " ERROR - pytorch_inf venv missing at $venvPython" | log
+    " ERROR - Prep state is corrupt. Re-prep required:" | log
+    " ERROR -   delete C:\hobl_bin\prep_status\pytorch_inf<version> on the DUT and re-run." | log
+    Exit 1
+}
+"Using venv python: $venvPython" | log
+
+"Validating venv has required packages..." | log
+& $venvPython -c "import torch, transformers; print('torch', torch.__version__, '| transformers', transformers.__version__)" 2>&1 | log
+if ($LASTEXITCODE -ne 0) {
+    " ERROR - venv has missing/broken Python packages (import failed)." | log
+    " ERROR - Possible causes: Defender quarantine, disk cleanup, or external tampering." | log
+    " ERROR - Re-prep required:" | log
+    " ERROR -   delete C:\hobl_bin\prep_status\pytorch_inf<version> on the DUT and re-run." | log
+    Exit 1
+}
+
 "-- Extract log directory from logFile path" | log
 $logDir = Split-Path -Parent $logFile
 "Log directory: $logDir" | log
@@ -286,9 +312,9 @@ Write-RunPhaseMarker "phase.run_build.start"
 "-- Run LLM Phi-4-mini inferencing" | log
 if ($noGpu) {
     "Running in CPU-only mode (--no-gpu)" | log
-    python inference.py --prompt "What is the meaning of life?" --log-dir "$logDir" --no-gpu > "$logDir\pytorch_inf_output.txt" 2>&1
+    & $venvPython inference.py --prompt "What is the meaning of life?" --log-dir "$logDir" --no-gpu > "$logDir\pytorch_inf_output.txt" 2>&1
 } else {
-    python inference.py --prompt "What is the meaning of life?" --log-dir "$logDir" > "$logDir\pytorch_inf_output.txt" 2>&1
+    & $venvPython inference.py --prompt "What is the meaning of life?" --log-dir "$logDir" > "$logDir\pytorch_inf_output.txt" 2>&1
 }
 check($lastexitcode)
 Write-RunPhaseMarker "phase.run_build.end"

--- a/scenarios/windows/pytorch_inf/pytorch_inf_resources/pytorch_inf_run.ps1
+++ b/scenarios/windows/pytorch_inf/pytorch_inf_resources/pytorch_inf_run.ps1
@@ -298,14 +298,16 @@ if ($LASTEXITCODE -ne 0) {
     Exit 1
 }
 
-"-- Extract log directory from logFile path" | log
+"-- Extract log directory from logFile path for storing additional logs" | log
 $logDir = Split-Path -Parent $logFile
-"Log directory: $logDir" | log
+"Log directory for storing additional logs: $logDir" | log
 
 # inference.py writes pytorch_inference_info.csv to --log-dir with these metrics:
 #   time_to_first_token_ms, time_to_first_token_s, tokens_per_second,
 #   total_tokens_generated, total_generation_time_s, ai_model, ai_device
 $inferenceCSV = Join-Path $logDir "pytorch_inference_info.csv"
+"-- Metrics will be stored in $inferenceCSV" | log
+
 Write-RunPhaseMarker "phase.run_prep.end"
 Write-RunPhaseMarker "phase.run_build.start"
 

--- a/scenarios/windows/pytorch_inf/pytorch_inf_resources/pytorch_inf_teardown.ps1
+++ b/scenarios/windows/pytorch_inf/pytorch_inf_resources/pytorch_inf_teardown.ps1
@@ -92,8 +92,19 @@ Set-Location "$scriptDrive\hobl_bin\pytorch_inf_resources"
 checkCmd($?)
 
 "-- Cleanup GPU caching" | log
-python inference.py --cleanup-gpu
-check($lastexitcode)
+# Use the per-scenario venv python (created during prep) rather than the
+# shared pyenv python. The venv has torch installed; the shared pyenv
+# environment may not after other scenarios run.
+$venvPython = "$scriptDrive\hobl_bin\pytorch_inf_resources\.venv\Scripts\python.exe"
+if (-not (Test-Path $venvPython)) {
+    "-- venv missing at $venvPython; skipping GPU cleanup (will be recreated on next prep)" | log
+    Exit 0
+}
+& $venvPython inference.py --cleanup-gpu
+# Don't treat cleanup failure as fatal — teardown should not break the run cycle.
+if ($lastexitcode -ne 0) {
+    "-- GPU cleanup returned exit code $lastexitcode (non-fatal)" | log
+}
 
 "-- pytorch_inf teardown completed" | log
 Exit 0

--- a/scenarios/windows/spring_petclinic/spring_petclinic.py
+++ b/scenarios/windows/spring_petclinic/spring_petclinic.py
@@ -14,7 +14,7 @@ from datetime import datetime
 class SpringPetClinic(core.app_scenario.Scenario):
 
     module = __module__.split('.')[-1]
-    prep_version = "7"
+    prep_version = "8"
     resources = module + "_resources"
 
 

--- a/scenarios/windows/spring_petclinic/spring_petclinic_resources/spring_petclinic_run.ps1
+++ b/scenarios/windows/spring_petclinic/spring_petclinic_resources/spring_petclinic_run.ps1
@@ -121,8 +121,15 @@ Set-Location "$scriptDrive\spring-petclinic"
 # ============================================================================
 # Clean phase (not timed)
 # ============================================================================
+# Redirect Maven output to a per-phase log under hobl_data so it is preserved
+# in the results share. Without redirection, stdout goes only to the RPC
+# buffer and is lost on RPC timeout. Build/test phases below are wrapped in
+# Measure-Command which DISCARDS stdout entirely, so file redirection is the
+# only way to capture their output.
 "-- spring_petclinic clean started" | log
-.\mvnw.cmd "-Dmaven.repo.local=$scriptDrive\temp\m2-spring-petclinic" clean
+$mavenCleanLog = "$scriptDrive\hobl_data\spring_petclinic_maven_clean_$($logSuffix.ToLower()).log"
+"-- Maven clean output: $mavenCleanLog" | log
+.\mvnw.cmd "-Dmaven.repo.local=$scriptDrive\temp\m2-spring-petclinic" clean *> $mavenCleanLog
 check($lastexitcode)
 "-- spring_petclinic clean completed" | log
 
@@ -133,11 +140,14 @@ check($lastexitcode)
 Write-RunPhaseMarker "phase.run_prep.end"
 Write-RunPhaseMarker "phase.run_build.start"
 
+$mavenBuildLog = "$scriptDrive\hobl_data\spring_petclinic_maven_build_$($logSuffix.ToLower()).log"
+"-- Maven build output: $mavenBuildLog" | log
+
 $buildDuration = Measure-Command {
-    .\mvnw.cmd -o "-Dmaven.repo.local=$scriptDrive\temp\m2-spring-petclinic" "-DskipTests" package
+    .\mvnw.cmd -o "-Dmaven.repo.local=$scriptDrive\temp\m2-spring-petclinic" "-DskipTests" package *> $mavenBuildLog
 }
 if ($LASTEXITCODE -ne 0) {
-    " ERROR - Offline build failed. Ensure prep completed online and populated $scriptDrive\temp\m2-spring-petclinic" | log
+    " ERROR - Offline build failed. See $mavenBuildLog for Maven output. Ensure prep completed online and populated $scriptDrive\temp\m2-spring-petclinic" | log
     Exit 1
 }
 
@@ -151,11 +161,14 @@ Write-RunPhaseMarker "phase.run_test.start"
 # ============================================================================
 "-- spring_petclinic test started" | log
 
+$mavenTestLog = "$scriptDrive\hobl_data\spring_petclinic_maven_test_$($logSuffix.ToLower()).log"
+"-- Maven test output: $mavenTestLog" | log
+
 $testDuration = Measure-Command {
-    .\mvnw.cmd -o "-Dmaven.repo.local=$scriptDrive\temp\m2-spring-petclinic" test
+    .\mvnw.cmd -o "-Dmaven.repo.local=$scriptDrive\temp\m2-spring-petclinic" test *> $mavenTestLog
 }
 if ($LASTEXITCODE -ne 0) {
-    " ERROR - Offline test failed. Ensure prep completed online and populated $scriptDrive\temp\m2-spring-petclinic" | log
+    " ERROR - Offline test failed. See $mavenTestLog for Maven output. Ensure prep completed online and populated $scriptDrive\temp\m2-spring-petclinic" | log
     Exit 1
 }
 Write-RunPhaseMarker "phase.run_test.end"

--- a/scenarios/windows/vscode/vscode.py
+++ b/scenarios/windows/vscode/vscode.py
@@ -14,7 +14,7 @@ import time
 class Vscode(scenarios.app_scenario.Scenario):
 
     module = __module__.split('.')[-1]
-    prep_version = "8"
+    prep_version = "9"
     resources = module + "_resources"
 
 

--- a/scenarios/windows/vscode/vscode_resources/vscode_prep.ps1
+++ b/scenarios/windows/vscode/vscode_resources/vscode_prep.ps1
@@ -203,9 +203,20 @@ try {
 $pyenvRoot = "$env:USERPROFILE\.pyenv"
 $env:PATH = "$pyenvRoot\pyenv-win\bin;$pyenvRoot\pyenv-win\shims;$env:PATH"
 
+# --- Install Python via pyenv (conditional — DO NOT use -f) ---
+# Force-reinstall (`-f`) wipes the pyenv version directory including any packages
+# installed by other scenarios that share this Python version. VS Code only needs
+# the interpreter (for node-gyp during native module builds) so no venv is
+# required — but we must avoid wiping it.
 "-- Installing Python $pythonVersion via pyenv" | log
-pyenv install $pythonVersion -f
-check($lastexitcode)
+$installedVersions = (pyenv versions --bare 2>$null) -split "`n" | ForEach-Object { $_.Trim() }
+if ($installedVersions -notcontains $pythonVersion) {
+    "Installing Python $pythonVersion via pyenv..." | log
+    pyenv install $pythonVersion
+    check($lastexitcode)
+} else {
+    "Python $pythonVersion already installed via pyenv — preserving existing install" | log
+}
 
 "Setting Python $pythonVersion as global version" | log
 pyenv global $pythonVersion

--- a/scenarios/windows/vscode/vscode_resources/vscode_run.ps1
+++ b/scenarios/windows/vscode/vscode_resources/vscode_run.ps1
@@ -183,14 +183,24 @@ $time = Get-Date -Format "HH:mm:ss"
 Write-RunPhaseMarker "phase.run_prep.end"
 Write-RunPhaseMarker "phase.run_build.start"
 
+# Redirect npm output to a per-phase log so it is preserved in the results
+# share. Measure-Command discards pipeline output entirely; without a file
+# redirect, npm's output is lost.
+$logDir = Split-Path $logFile -Parent
+$buildLog = "$logDir\vscode_build_$($logSuffix.ToLower()).log"
+"Build output: $buildLog" | log
+
 $buildTime = (Measure-Command {
-    npm run compile
+    npm run compile *> $buildLog
 }).TotalSeconds
 $buildExitCode = $LASTEXITCODE
 $buildTime = [math]::Round($buildTime, 2)
 
 "Build completed in ${buildTime}s" | log
-check($buildExitCode)
+if ($buildExitCode -ne 0) {
+    " ERROR - npm compile failed. See $buildLog for details." | log
+    Exit 1
+}
 Write-RunPhaseMarker "phase.run_build.end"
 Write-RunPhaseMarker "phase.run_results.start"
 


### PR DESCRIPTION
## Summary

This PR addresses a class of shared-state bug in HOBL scenarios where one scenario's prep silently wiped another scenario's Python site-packages on the DUT, plus a set of diagnosability and consistency fixes uncovered while debugging it. Validated end-to-end on both Windows (10/10 scenarios) and macOS (11/11 scenarios) lab DUTs.

## Why

Several Windows scenarios share a single `pyenv-win` Python version (`3.12.10-arm`: `pytorch_inf`, `llvm`, `nodejs`, `vscode`, `opencv_build`, `fast_api`). `pyenv install <version> -f` deletes and re-extracts the entire `~\.pyenv\pyenv-win\versions\<version>\` directory — including `Lib\site-packages\`. When `llvm`/`vscode`/`nodejs` preps ran with `-f`, they wiped `torch` (and every other pip-installed package) out from under `pytorch_inf` and `fast_api`. Because HOBL's `prep_status` file said prep was "done," subsequent iterations skipped prep and failed with a cryptic `ModuleNotFoundError: torch` deep inside the workload.

The same hazard exists on macOS for scenarios that share `3.12.10` via `pyenv`. That broader fix is deferred to a follow-up PR (see "Out of scope" below).

## Windows changes

### Per-scenario venv isolation (the actual fix)
- **`fast_api` and `pytorch_inf`** now create a per-scenario venv at `C:\hobl_bin\<scenario>_resources\.venv\` and invoke `python.exe` / `pip.exe` from that venv by absolute path. The venv lives outside `~\.pyenv\pyenv-win\versions\` and survives any other scenario's `pyenv install -f`.
- **Run scripts** call the venv's `python.exe` directly (e.g. `& $venvPython -m coverage run -m pytest tests`) and include a fail-fast import guard at the top:
  ```powershell
  & $venvPython -c "import torch, transformers; ..." 2>&1 | log
  if ($LASTEXITCODE -ne 0) {
      " ERROR - venv has missing/broken Python packages." | log
      " ERROR - Re-prep required: delete C:\hobl_bin\prep_status\<scenario><version> on the DUT and re-run." | log
      Exit 1
  }
  ```
  This turns a 200-lines-in `ModuleNotFoundError` into an actionable failure at run-start.

### Drop `-f` from all Windows pyenv-using preps
`fast_api`, `llvm`, `nodejs`, `pytorch_inf`, and `vscode` now use a conditional install pattern:
```powershell
$installedVersions = (pyenv versions --bare 2>$null) -split "`n" | ForEach-Object { $_.Trim() }
if ($installedVersions -notcontains $pythonVersion) {
    pyenv install $pythonVersion
} else {
    "Python $pythonVersion already installed via pyenv — preserving existing install" | log
}
```
No more force-reinstalls of a shared toolchain.

### Python version alignment (`fast_api` 3.11.9-arm → 3.12.10-arm)
`pyenv-win`'s `3.11.9-arm` build has a broken stdlib on ARM64 (`could not import runpy module`), which made `python -m venv` fail. Moving `fast_api` to `3.12.10-arm` also consolidates it onto the same shared version used by `pytorch_inf`/`llvm`/`vscode`/`nodejs`/`opencv_build`, which is now safe thanks to the venv isolation above.

### Dual-logging in run scripts
`fast_api`, `pytorch_inf`, `vscode`, `opencv_build`, and `spring_petclinic` run scripts now tee build/test output to per-phase log files in `$LOG_DIR\hobl_data\` (e.g. `pytorch_inf_run.log`, `fast_api_test.log`). When HOBL's RPC times out we lose stdout, so the on-DUT log file is what remains to debug from. Matches the gold-standard pattern already in `foundrylocal`.

### prep_version bumps (Windows)
Bumped for every scenario whose prep or run script changed in ways that need to ship to existing DUTs:
- `fast_api` 5 → 8 (venv creation, Python 3.12.10, conditional install, run-script venv usage)
- `llvm` 8 → 9 (conditional install)
- `nodejs` 7 → 8 (conditional install)
- `pytorch_inf` 13 → 14 (venv creation, conditional install)
- `vscode` 8 → 9 (conditional install)
- `opencv_build` 6 → 7 (run-script dual-logging)
- `spring_petclinic` 7 → 8 (run-script dual-logging)

## macOS changes

### Dual-logging in run scripts
Added the same dual-logging redirects to 8 macOS run scripts so build/test output is captured on the DUT even when HOBL's RPC times out: `mac_fast_api`, `mac_llvm`, `mac_mlperf`, `mac_net_aspire`, `mac_nodejs`, `mac_opencv_build`, `mac_spring_petclinic`, `mac_vscode`.

### Bug fix: `mac_mlperf` undefined `$LOG_DIR`
`mac_mlperf_run.sh` referenced a `$LOG_DIR` variable that doesn't exist in that script (the scenario uses `$OUTPUT_DIR`). The dual-logging redirect would have silently written to the wrong/empty path. Fixed to use `$OUTPUT_DIR`.

### Python version alignment
- `mac_fast_api` 3.11.9 → 3.12.10
- `mac_vscode` 3.10.11 → 3.12.10

Brings these onto the same shared `3.12.10` already used by `mac_pytorch_inf`/`mac_llvm`/`mac_nodejs`/`mac_opencv_build`/`mac_net_aspire`, which aligns macOS with the Windows consolidation and reduces total pyenv versions installed on the DUT.

### prep_version bumps (macOS)
- `mac_fast_api` 5 → 7 (Python alignment)
- `mac_llvm` 5 → 6 (run-script dual-logging)
- `mac_mlperf` 5 → 6 (run-script dual-logging + LOG_DIR fix)
- `mac_net_aspire` 8 → 9 (run-script dual-logging)
- `mac_nodejs` 4 → 5 (run-script dual-logging)
- `mac_opencv_build` 4 → 5 (run-script dual-logging)
- `mac_spring_petclinic` 8 → 9 (run-script dual-logging)
- `mac_vscode` 6 → 8 (Python alignment + run-script dual-logging)

## Documentation

`.github/copilot-instructions.md` gains two new sections so future contributors don't reintroduce the same class of bug:
1. **Shared-State Hazards Across Scenarios** — bans `pyenv install -f` / `nvm --reinstall-packages-from` / `brew reinstall` / `rustup --force-non-host` for shared toolchains, prescribes the per-scenario-venv pattern (path, creation pattern, absolute-path invocation, run-start import guard), and documents why `prep_status` alone isn't a reliable signal that prep artifacts are intact.
2. **Diagnosing Scenario Failures After iter 0 Succeeded** — ordered checklist for triaging the exact symptom that motivated this PR (works iter 0, fails iter N with missing-package errors).

## Out of scope (follow-up PR)

The same per-scenario venv pattern should be applied to macOS scenarios that share `3.12.10` (`mac_pytorch_inf`, `mac_fast_api`, etc.). That's intentionally not in this PR — the macOS changes here are limited to dual-logging, the `mac_mlperf` bug fix, and Python version alignment so this PR stays reviewable. The macOS venv parity is tracked as follow-up work.