### PR TITLE
# macOS scenario prep reliability + VS Code spdlog compatibility

### DIFF
--- a/scenarios/macos/mac_foundrylocal/mac_foundrylocal_resources/mac_foundrylocal_setup.sh
+++ b/scenarios/macos/mac_foundrylocal/mac_foundrylocal_resources/mac_foundrylocal_setup.sh
@@ -51,8 +51,16 @@ export PATH="$HOME/bin:$PATH"
 # ============================================================================
 log "Step 1: Starting Foundry service..."
 
-log "Running: foundry service start (in background)"
-foundry service start &
+# Spawn the foundry service fully detached: redirect its stdio away from the
+# inherited RPC pipes and disown it so the parent shell's exit isn't blocked
+# on the daemon and the RPC layer (SimpleRemote) gets EOF on stdout/stderr
+# immediately when this script returns. A bare `foundry service start &`
+# leaves the daemon owning the script's stdout fd; SimpleRemote then waits
+# for EOF and times out at 30 minutes even though setup completed.
+FOUNDRY_SERVICE_LOG="$LOG_DIR/mac_foundrylocal_foundry_service.log"
+log "Running: foundry service start (background, logs -> $FOUNDRY_SERVICE_LOG)"
+nohup foundry service start </dev/null >>"$FOUNDRY_SERVICE_LOG" 2>&1 &
+disown 2>/dev/null || true
 
 # Wait for service to be ready
 log "Waiting for Foundry service to be ready..."

--- a/scenarios/macos/mac_net_aspire/mac_net_aspire.py
+++ b/scenarios/macos/mac_net_aspire/mac_net_aspire.py
@@ -14,7 +14,7 @@ import time
 class MacNetAspire(core.app_scenario.Scenario):
 
     module = __module__.split('.')[-1]
-    prep_version = "9"
+    prep_version = "10"
     resources = module + "_resources"
 
 

--- a/scenarios/macos/mac_net_aspire/mac_net_aspire_resources/mac_net_aspire_prep.sh
+++ b/scenarios/macos/mac_net_aspire/mac_net_aspire_resources/mac_net_aspire_prep.sh
@@ -180,8 +180,22 @@ log "✓ Python version confirmed: $PYTHON_VERSION"
 # iterations (which use plain --build) pass cleanly.
 log "-- Regenerating ConfigurationSchema.json files"
 cd $BIN_DIR/aspire
-./build.sh --restore --build /p:UpdateConfigurationSchema=true
-check_status "ConfigurationSchema regeneration"
+# Capture build output so a failure is diagnosable. Without this the entire
+# MSBuild/dotnet error was swallowed and the prep log only said
+# "ConfigurationSchema regeneration failed" with no further clues.
+ASPIRE_BUILD_LOG="$LOG_DIR/mac_net_aspire_build.log"
+log "   build output -> $ASPIRE_BUILD_LOG"
+./build.sh --restore --build /p:UpdateConfigurationSchema=true >>"$ASPIRE_BUILD_LOG" 2>&1
+ASPIRE_BUILD_RC=$?
+if [ $ASPIRE_BUILD_RC -ne 0 ]; then
+    log " ERROR - ConfigurationSchema regeneration failed (rc=$ASPIRE_BUILD_RC)."
+    log " ERROR - See $ASPIRE_BUILD_LOG for full build output. Last 40 lines:"
+    tail -n 40 "$ASPIRE_BUILD_LOG" 2>/dev/null | while IFS= read -r line; do
+        log "   | $line"
+    done
+    exit 1
+fi
+log "✓ ConfigurationSchema regeneration successful"
 
 log ""
 log "✓ All checks passed"

--- a/scenarios/macos/mac_opencv_build/mac_opencv_build.py
+++ b/scenarios/macos/mac_opencv_build/mac_opencv_build.py
@@ -14,7 +14,7 @@ import time
 class MacOpencvBuild(core.app_scenario.Scenario):
 
     module = __module__.split('.')[-1]
-    prep_version = "5"
+    prep_version = "6"
     resources = module + "_resources"
 
 

--- a/scenarios/macos/mac_opencv_build/mac_opencv_build_resources/mac_opencv_build_prep.sh
+++ b/scenarios/macos/mac_opencv_build/mac_opencv_build_resources/mac_opencv_build_prep.sh
@@ -157,10 +157,29 @@ if [ "$PYTHON_VERSION" != "3.12.10" ]; then
 fi
 log "✓ Python version confirmed: $PYTHON_VERSION"
 
-log "-- Installing CMake"
-brew install cmake
-check_status "CMake installation"
+log "-- Installing CMake and FFmpeg 6"
+brew install cmake ffmpeg@6
+check_status "CMake and FFmpeg 6 installation"
 check_command "cmake" || exit 1
+
+# OpenCV 4.10.0 is compatible with the FFmpeg 6 API surface. Windows uses the
+# FFmpeg revision pinned by OpenCV's 4.10 packaging; on macOS Homebrew's rolling
+# `ffmpeg` formula can advance to 7.x, which breaks OpenCV 4.10 videoio compile
+# with removed APIs like `avcodec_close`. Prefer the keg-only ffmpeg@6 formula
+# explicitly so mac stays aligned with the Windows workload.
+FFMPEG6_PREFIX="$(/opt/homebrew/bin/brew --prefix ffmpeg@6 2>/dev/null)"
+if [ -z "$FFMPEG6_PREFIX" ] || [ ! -d "$FFMPEG6_PREFIX" ]; then
+    log " ERROR - ffmpeg@6 prefix could not be resolved"
+    exit 1
+fi
+export PKG_CONFIG_PATH="$FFMPEG6_PREFIX/lib/pkgconfig:$PKG_CONFIG_PATH"
+log "✓ Using ffmpeg@6 from: $FFMPEG6_PREFIX"
+FFMPEG_VERSION=$(PKG_CONFIG_PATH="$PKG_CONFIG_PATH" pkg-config --modversion libavcodec 2>/dev/null)
+if [ -z "$FFMPEG_VERSION" ]; then
+    log " ERROR - pkg-config could not resolve libavcodec from ffmpeg@6"
+    exit 1
+fi
+log "✓ libavcodec version resolved via pkg-config: $FFMPEG_VERSION"
 
 log "-- Creating build directory"
 mkdir -p $BIN_DIR/build_opencv

--- a/scenarios/macos/mac_pytorch_inf/mac_pytorch_inf.py
+++ b/scenarios/macos/mac_pytorch_inf/mac_pytorch_inf.py
@@ -14,7 +14,7 @@ import time
 class MacPytorchInf(core.app_scenario.Scenario):
 
     module = __module__.split('.')[-1]
-    prep_version = "7"
+    prep_version = "8"
     resources = module + "_resources"
 
 

--- a/scenarios/macos/mac_pytorch_inf/mac_pytorch_inf_resources/mac_pytorch_inf_prep.sh
+++ b/scenarios/macos/mac_pytorch_inf/mac_pytorch_inf_resources/mac_pytorch_inf_prep.sh
@@ -34,8 +34,16 @@ check_command() {
 
 # Always copy resources to pick up script/config changes
 log "-- Copying resources to $BIN_DIR/mac_pytorch_inf_resources"
-mkdir -p "$BIN_DIR/mac_pytorch_inf_resources"
-cp -r "$(dirname "$0")"/* "$BIN_DIR/mac_pytorch_inf_resources/"
+SRC_RES_DIR="$(cd "$(dirname "$0")" && pwd)"
+DST_RES_DIR="$BIN_DIR/mac_pytorch_inf_resources"
+mkdir -p "$DST_RES_DIR"
+check_status "resource directory creation"
+if [ "$SRC_RES_DIR" = "$DST_RES_DIR" ]; then
+    log "✓ Resource copy skipped (already running from $DST_RES_DIR)"
+else
+    cp -r "$SRC_RES_DIR"/* "$DST_RES_DIR/"
+    check_status "resource copy"
+fi
 
 echo "-- mac_pytorch_inf_prep.sh started $(date)" > "$LOG_FILE"
 log "-- pytorch_inf prep started"

--- a/scenarios/macos/mac_vscode/mac_vscode.py
+++ b/scenarios/macos/mac_vscode/mac_vscode.py
@@ -14,7 +14,7 @@ import time
 class MacVscode(scenarios.app_scenario.Scenario):
 
     module = __module__.split('.')[-1]
-    prep_version = "8"
+    prep_version = "16"
     resources = module + "_resources"
 
 

--- a/scenarios/macos/mac_vscode/mac_vscode_resources/mac_vscode_prep.sh
+++ b/scenarios/macos/mac_vscode/mac_vscode_resources/mac_vscode_prep.sh
@@ -50,6 +50,21 @@ if [ ! -d "$BIN_DIR" ]; then
     exit 1
 fi
 
+# Always copy resources to pick up script/config/patch changes.
+# This keeps prep resilient when invoked from different working directories
+# while still expecting files under $BIN_DIR/mac_vscode_resources.
+log "-- Copying resources to $BIN_DIR/mac_vscode_resources"
+SRC_RES_DIR="$(cd "$(dirname "$0")" && pwd)"
+DST_RES_DIR="$BIN_DIR/mac_vscode_resources"
+mkdir -p "$DST_RES_DIR"
+check_status "resource directory creation"
+if [ "$SRC_RES_DIR" = "$DST_RES_DIR" ]; then
+    log "✓ Resource copy skipped (already running from $DST_RES_DIR)"
+else
+    cp -r "$SRC_RES_DIR"/* "$DST_RES_DIR/"
+    check_status "resource copy"
+fi
+
 cd $BIN_DIR || { log " ERROR - Failed to change to $BIN_DIR"; exit 1; }
 
 # 1. Ensure Xcode command-line tools are installed
@@ -160,29 +175,83 @@ check_status "VS Code checkout v1.106.2"
 
 # 7. Install npm dependencies
 log "-- Installing npm dependencies (this may take 10-20 minutes)..."
-# First attempt - this will fail on @vscode/spdlog due to Apple Clang consteval issue on Darwin 25.4+
-npm install --loglevel=error 2>/dev/null
-
-# Patch bundled fmt in @vscode/spdlog to work around Apple Clang consteval issue
-SPDLOG_FMT_DIR="node_modules/@vscode/spdlog/deps/spdlog/include/spdlog/fmt/bundled"
-if [ -d "$SPDLOG_FMT_DIR" ]; then
-    log "-- Patching spdlog fmt headers (consteval -> constexpr)"
-    sed -i '' 's/consteval/constexpr/g' "$SPDLOG_FMT_DIR/format.h"
-    sed -i '' 's/consteval/constexpr/g' "$SPDLOG_FMT_DIR/core.h"
-    check_status "spdlog fmt patch"
-
-    # Rebuild just spdlog with the patched source (npm uses its bundled node-gyp)
-    log "-- Rebuilding @vscode/spdlog..."
-    npm rebuild @vscode/spdlog
-    check_status "spdlog rebuild"
-else
-    log "-- No spdlog fmt patch needed"
+# Install deps without lifecycle scripts first so @vscode/spdlog headers are
+# guaranteed to exist for patching before node-gyp build kicks in.
+NPM_FIRST_LOG="$LOG_DIR/mac_vscode_npm_install_first.log"
+log "   phase-1 npm install (--ignore-scripts) output -> $NPM_FIRST_LOG"
+npm install --ignore-scripts --loglevel=error >>"$NPM_FIRST_LOG" 2>&1
+NPM_FIRST_RC=$?
+if [ $NPM_FIRST_RC -ne 0 ]; then
+    log " ERROR - First npm install phase failed (rc=$NPM_FIRST_RC)."
+    log " ERROR - See $NPM_FIRST_LOG for the underlying error."
+    exit 1
 fi
+log "✓ phase-1 npm install completed"
+
+# Apply a checked-in patch (durable and auditable) instead of ad-hoc string
+# replacement in the script. This keeps the workaround deterministic for the
+# pinned VS Code tag.
+# TODO: Revisit/remove this patch when we move off VS Code 1.106.2 or when
+# upstream @vscode/spdlog/fmt builds cleanly on Darwin 25+ with Node 22.
+PATCH_FILE="$BIN_DIR/mac_vscode_resources/spdlog_fmt_darwin25.patch"
+if [ ! -f "$PATCH_FILE" ]; then
+    log " ERROR - Required patch file not found: $PATCH_FILE"
+    exit 1
+fi
+
+CORE_H="node_modules/@vscode/spdlog/deps/spdlog/include/spdlog/fmt/bundled/core.h"
+if [ ! -f "$CORE_H" ]; then
+    log " ERROR - Expected spdlog header not found: $CORE_H"
+    exit 1
+fi
+
+# Fast-path: if this package build already carries the Apple-compatible
+# constexpr form, skip patching entirely.
+if grep -Eq '^#[[:space:]]*define[[:space:]]+FMT_CONSTEVAL[[:space:]]+constexpr$' "$CORE_H"; then
+    log "✓ spdlog/fmt already in compatible state (FMT_CONSTEVAL constexpr)"
+else
+    log "-- Applying spdlog/fmt compatibility patch: $PATCH_FILE"
+    if git apply --check "$PATCH_FILE" >/dev/null 2>&1; then
+        git apply "$PATCH_FILE"
+        check_status "spdlog/fmt patch apply"
+    elif git apply --reverse --check "$PATCH_FILE" >/dev/null 2>&1; then
+        log "✓ spdlog/fmt patch already applied"
+    else
+        # Fallback for minor upstream drift where patch hunk context changed
+        # but the required token replacement is still well-defined.
+        if grep -Eq '^#[[:space:]]*define[[:space:]]+FMT_CONSTEVAL[[:space:]]+consteval$' "$CORE_H"; then
+            log "-- Patch did not apply cleanly; applying tolerant fallback edit in $CORE_H"
+            sed -E -i '' 's@^#[[:space:]]*define[[:space:]]+FMT_CONSTEVAL[[:space:]]+consteval$@#  define FMT_CONSTEVAL constexpr@' "$CORE_H"
+            check_status "spdlog/fmt fallback edit"
+            if grep -Eq '^#[[:space:]]*define[[:space:]]+FMT_CONSTEVAL[[:space:]]+constexpr$' "$CORE_H"; then
+                log "✓ spdlog/fmt fallback edit applied"
+            else
+                log " ERROR - spdlog/fmt fallback edit failed to verify"
+                exit 1
+            fi
+        else
+            log " ERROR - spdlog/fmt patch does not apply cleanly and FMT_CONSTEVAL token was not found in core.h"
+            exit 1
+        fi
+    fi
+fi
+
+# Rebuild just spdlog with the patched source (npm uses its bundled node-gyp)
+log "-- Rebuilding @vscode/spdlog..."
+npm rebuild @vscode/spdlog
+check_status "spdlog rebuild"
 
 # Re-run npm install to complete any remaining steps (postinstall, etc.)
 log "-- Completing npm install..."
-npm install --loglevel=error
-check_status "npm install"
+NPM_FINAL_LOG="$LOG_DIR/mac_vscode_npm_install_final.log"
+log "   phase-2 npm install output -> $NPM_FINAL_LOG"
+npm install --loglevel=error >>"$NPM_FINAL_LOG" 2>&1
+if [ $? -ne 0 ]; then
+    log " ERROR - Final npm install failed."
+    log " ERROR - See $NPM_FINAL_LOG for details."
+    exit 1
+fi
+log "✓ npm install successful"
 
 log ""
 log "✓ All checks passed"

--- a/scenarios/macos/mac_vscode/mac_vscode_resources/spdlog_fmt_darwin25.patch
+++ b/scenarios/macos/mac_vscode/mac_vscode_resources/spdlog_fmt_darwin25.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/@vscode/spdlog/deps/spdlog/include/spdlog/fmt/bundled/core.h b/node_modules/@vscode/spdlog/deps/spdlog/include/spdlog/fmt/bundled/core.h
+index 8f1a6f1..b7a5f0c 100644
+--- a/node_modules/@vscode/spdlog/deps/spdlog/include/spdlog/fmt/bundled/core.h
++++ b/node_modules/@vscode/spdlog/deps/spdlog/include/spdlog/fmt/bundled/core.h
+@@ -263,7 +263,7 @@
+ #  define FMT_USE_CONSTEVAL 0
+ #endif
+ #if FMT_USE_CONSTEVAL
+-#  define FMT_CONSTEVAL consteval
++#  define FMT_CONSTEVAL constexpr
+ #  define FMT_CONSTEXPR20 consteval
+ #else
+ #  define FMT_CONSTEVAL


### PR DESCRIPTION
## Summary
This PR fixes a set of reliability issues in macOS developer scenarios that caused intermittent prep failures and environment drift, and hardens the VS Code prep flow for Darwin 25+ toolchains.

Primary outcomes:
- Eliminates intermittent `mac_foundrylocal` setup timeout behavior.
- Makes `mac_vscode` prep resilient across package-layout drift and repeated runs.
- Improves diagnostics for `mac_net_aspire` prep failures.
- Aligns `mac_opencv_build` with OpenCV 4.10-compatible FFmpeg major versioning.
- Adds safer resource-copy behavior for scripts that may execute from target resource folders.

## Problem
We observed several macOS issues during repeated lab runs:
- `mac_foundrylocal`: setup could complete but RPC timed out due to inherited stdio from background service launch.
- `mac_vscode`: `@vscode/spdlog` build failed on Darwin 25+ (`consteval`/fmt compatibility path), with patch flow brittle to minor file/layout drift.
- `mac_net_aspire`: prep failure (`ConfigurationSchema regeneration`) was not actionable because build output was not captured.
- `mac_opencv_build`: OpenCV 4.10 build failures in FFmpeg integration path due to API mismatch with newer Homebrew FFmpeg.
- Resource copy blocks in mac scripts could fail or behave incorrectly when source == destination (script launched from resource folder).

## What changed
### `mac_foundrylocal`
- Updated service startup in `mac_foundrylocal_setup.sh` to fully detach process stdio from the invoking shell/RPC context.
- Goal: avoid setup completion followed by host-side timeout waiting on inherited file handles.

### `mac_vscode`
- Reworked prep flow in `mac_vscode_prep.sh`:
  - `npm install --ignore-scripts` first.
  - Check if `core.h` is already in compatible state (`FMT_CONSTEVAL constexpr`) and skip patching when already compatible.
  - Apply checked-in patch artifact when needed: `spdlog_fmt_darwin25.patch`.
  - Add tolerant verified fallback edit when patch hunks do not apply cleanly due to minor context drift.
  - Rebuild `@vscode/spdlog`, then run final `npm install`.
- Added patch artifact file:
  - `scenarios/macos/mac_vscode/mac_vscode_resources/spdlog_fmt_darwin25.patch`
- Added resource-copy guard to avoid self-copy failure when running from target resource dir.

### `mac_net_aspire`
- Updated `mac_net_aspire_prep.sh` to capture full build output to dedicated log and include failure context in prep log.
- Goal: failures are immediately diagnosable instead of generic "regeneration failed".

### `mac_opencv_build`
- Updated prep to install/use FFmpeg 6 pathing for OpenCV 4.10 compatibility and log the resolved FFmpeg/libavcodec version.
- Goal: avoid FFmpeg API mismatch errors in build path while keeping scenario intent stable.

### `mac_pytorch_inf`
- Added source==destination resource-copy guard in `mac_pytorch_inf_prep.sh`.
- Goal: avoid self-copy issues when prep executes from resource folder.

### Prep version bumps
Prep versions were incremented for updated scenarios so DUTs re-run prep and pick up script changes.

## Files changed
- `scenarios/macos/mac_foundrylocal/mac_foundrylocal_resources/mac_foundrylocal_setup.sh`
- `scenarios/macos/mac_net_aspire/mac_net_aspire.py`
- `scenarios/macos/mac_net_aspire/mac_net_aspire_resources/mac_net_aspire_prep.sh`
- `scenarios/macos/mac_opencv_build/mac_opencv_build.py`
- `scenarios/macos/mac_opencv_build/mac_opencv_build_resources/mac_opencv_build_prep.sh`
- `scenarios/macos/mac_pytorch_inf/mac_pytorch_inf.py`
- `scenarios/macos/mac_pytorch_inf/mac_pytorch_inf_resources/mac_pytorch_inf_prep.sh`
- `scenarios/macos/mac_vscode/mac_vscode.py`
- `scenarios/macos/mac_vscode/mac_vscode_resources/mac_vscode_prep.sh`
- `scenarios/macos/mac_vscode/mac_vscode_resources/spdlog_fmt_darwin25.patch`

## Validation
- Targeted macOS scenario verification was run on lab hardware.
- Per run verification, all targeted scenarios now pass after these fixes.