### PR TITLE
Web Prep Update & Cyberpunk Graphics Preset Update

### DIFF
--- a/scenarios/windows/cyberpunk/cyberpunk_settings_files/UserSettings_med_1080.json
+++ b/scenarios/windows/cyberpunk/cyberpunk_settings_files/UserSettings_med_1080.json
@@ -417,14 +417,14 @@
                     "type": "string_list",
                     "is_dynamic": true,
                     "value": "Medium",
-                    "index": 0
+                    "index": 2
                 },
                 {
                     "name": "ResolutionScaling",
                     "type": "string_list",
                     "is_dynamic": true,
-                    "value": "Off",
-                    "index": 0
+                    "value": "FSR2",
+                    "index": 2
                 },
                 {
                     "name": "DLSS_UNSUPPORTED",

--- a/scenarios/windows/web_prep/default_params.py
+++ b/scenarios/windows/web_prep/default_params.py
@@ -1,11 +1,8 @@
 # Copyright (c) Microsoft. All rights reserved.
 # Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-from functools import partial
 from core.parameters import Params
-import utilities.open_source.modules
-
-import_run_user_only = partial(utilities.open_source.modules.import_run_user_only, here=__file__)
+from utilities.open_source.modules import import_run_user_only
 
 def run():
     Params.setCalculated('scenario_section', __package__.split('.')[-1])

--- a/scenarios/windows/web_prep/web_prep.json
+++ b/scenarios/windows/web_prep/web_prep.json
@@ -31,7 +31,7 @@
     },
     {
         "children": [],
-        "delay": "2",
+        "delay": "10",
         "description": "",
         "enabled": true,
         "file_name": [


### PR DESCRIPTION
web_prep - increased the delay for screen capture on a large image as it was taking too long on some devices causing it to go into negative wait time.

cyberpunk - Updated graphics preset for medium 1080p to match the exact preset that cyberpunk has for medium.