### PR TITLE
Support for installing built in teams, Added Cinebench kill routine, Added more discharge features

### DIFF
--- a/scenarios/windows/cinebench.py
+++ b/scenarios/windows/cinebench.py
@@ -83,3 +83,11 @@ class Cinebench(core.app_scenario.Scenario):
             logging.info(f"Cinebench Single Core score: {score}")
         else:
             logging.info(f"Cinebench Multi Core score: {score}")
+
+    def kill(self):
+        # In case of scenario failure or termination, kill any applications left open here:
+        try:
+            self._kill("cinebench.exe")
+        except:
+            pass
+        return

--- a/scenarios/windows/discharge.py
+++ b/scenarios/windows/discharge.py
@@ -25,16 +25,23 @@ class Discharge(core.app_scenario.Scenario):
     Params.setDefault(module, 'resume_threshold', '100', desc="Percent battery level to discharge to")
     Params.setDefault(module, 'poll_period', '30', desc="How often to check battery level (default 30s)")
     Params.setDefault(module, 'run_scenario', '', desc="Run LVP, FishBowl, or GPU stress in the background", valOptions=["lvp", "fishbowl", "stress"])
-
-    Params.setOverride('global', 'tools', '')
-    Params.setOverride('global', 'prep_tools', '')
-    Params.setOverride('global', 'collection_enabled', '0')
+    Params.setDefault(module, 'leave_on_dc', '1', desc="Leave on DC power after discharge scenario (default 1 - keep charger off)") 
+    Params.setDefault(module, 'taper_workload', '0', desc="Stop workload to cool down device. resume_threshold + taper_workload. (default 0)")
 
     # Get parameters
     resume_threshold = int(Params.get(module, 'resume_threshold'))
     charge_off_call  = Params.get('global', 'charge_off_call')
+    charge_on_call   = Params.get('global', 'charge_on_call')
     poll_period      = int(Params.get(module, 'poll_period'))
     run_scenario     = Params.get(module, 'run_scenario')
+    leave_on_dc      = Params.get(module, 'leave_on_dc') 
+    taper_workload    = int(Params.get(module, 'taper_workload'))
+
+    Params.setOverride('global', 'tools', '')
+    Params.setOverride('global', 'collection_enabled', '0')
+
+    if not run_scenario:
+        Params.setOverride('global', 'prep_tools', '')
 
     run_dir     = Params.getCalculated('run_dir')
     params_file = Params.getCalculated('params_file')
@@ -42,20 +49,25 @@ class Discharge(core.app_scenario.Scenario):
     is_prep = True
 
 
-    def is_discharge_done(self):
+    def is_discharge_done(self, battery_level=None):
+        if battery_level is None:
+            battery_level = self.resume_threshold
         batt_level = self.getBattLevel()
-        logging.info(f"Battery level: {str(batt_level)} Expected Level: {str(self.resume_threshold)}")
+        logging.info(f"Battery level: {str(batt_level)} Expected Level: {str(battery_level)}")
 
-        if batt_level <= self.resume_threshold:
+        if batt_level <= battery_level:
             logging.info("Discharging complete")
             return True
         return False
 
-
-    def runTest(self):
+    def setup(self):
         logging.info("Discharging...")
         self._host_call(self.charge_off_call)
 
+        # Call base class setUp() to dump config, call tool callbacks, and start measurment
+        core.app_scenario.Scenario.setUp(self)
+
+    def runTest(self):
         if self.is_discharge_done():
             return
 
@@ -107,17 +119,25 @@ class Discharge(core.app_scenario.Scenario):
             time.sleep(30)
 
         while True:
-            if self.is_discharge_done():
+            if self.is_discharge_done(self.resume_threshold + self.taper_workload):
                 break
             else:
                 time.sleep(int(self.poll_period))
 
-        if p:
-            logging.info(f"Stopping {self.run_scenario.lower()}")
+        logging.info(f"Stopping {self.run_scenario.lower()}")
 
-            p.stdin.write(b"teardown\n")
-            p.stdin.flush()
-            p.wait()
+        p.stdin.write(b"teardown\n")
+        p.stdin.flush()
+        p.wait()
+
+        # Check if workload has been tapered if so then we need to finish discharing to resume_threshold
+        if self.taper_workload > 0:
+            logging.info("Workload tapered to cool down device. Now finishing discharging to resume_threshold.")
+            while True:
+                if self.is_discharge_done(self.resume_threshold):
+                    break
+                else:
+                    time.sleep(int(self.poll_period))
 
 
     def getBattLevel(self):
@@ -127,6 +147,13 @@ class Discharge(core.app_scenario.Scenario):
 
         return int(batt_level)
 
+    def tearDown(self):
+        # Call base class tearDown() to stop measurment and call tool callbacks
+        core.app_scenario.Scenario.tearDown(self)
+
+        if self.leave_on_dc == '0':
+            logging.info("Re-enabling charging...")
+            self._host_call(self.charge_on_call)
 
     def kill(self):
         if self.run_scenario.lower() == "lvp":

--- a/scenarios/windows/teams_install.py
+++ b/scenarios/windows/teams_install.py
@@ -168,7 +168,7 @@ class TeamsInstall(core.app_scenario.Scenario):
                         # Press Windows key, type "Microsoft Teams", and hit Enter to launch.
                         # Safe to do here because we've already confirmed the package is installed,
                         # so search will surface the app rather than a Bing/Store web suggestion.
-                        ActionChains(desktop).send_keys(Keys.META).perform()
+                        ActionChains(desktop).key_down(Keys.META).key_up(Keys.META).perform()
                         time.sleep(2)
                         ActionChains(desktop).send_keys("Microsoft Teams").perform()
                         time.sleep(2)

--- a/scenarios/windows/teams_install.py
+++ b/scenarios/windows/teams_install.py
@@ -76,6 +76,14 @@ class TeamsInstall(core.app_scenario.Scenario):
             logging.info("Uploading movie file " + "ppt.mp4" + " to " + dest)
             self._upload(source, dest)
 
+        # Get desktop driver
+        logging.debug("Launching WinAppDriver.exe on DUT.")
+        self._call([self.dut_exec_path + "\\WindowsApplicationDriver\\WinAppDriver.exe", self.dut_resolved_ip + " " + self.app_port + " /forcequit"], blocking=False)
+        logging.info("Creating Desktop Driver")
+        desired_caps = {}
+        desired_caps["app"] = "Root"
+        desktop = self._launchApp(desired_caps, track_driver=False)
+        desktop.implicitly_wait(10)
 
         # Run Install if install_teams is set to 1
         if self.install_teams == "1":
@@ -125,14 +133,58 @@ class TeamsInstall(core.app_scenario.Scenario):
             self._call(['cmd.exe', r'/C reg.exe Add "HKCU\Software\Microsoft\Windows\CurrentVersion\CapabilityAccessManager\ConsentStore\microphone\MSTeams_8wekyb3d8bbwe" /v Value /t REG_SZ /d Allow /f'], expected_exit_code="")
             self._call(['cmd.exe', r'/C reg.exe Add "HKCU\Software\Microsoft\Windows\CurrentVersion\CapabilityAccessManager\ConsentStore\webcam\MSTeams_8wekyb3d8bbwe" /v Value /t REG_SZ /d Allow /f'], expected_exit_code="")
 
-        # Get desktop driver
-        logging.debug("Launching WinAppDriver.exe on DUT.")
-        self._call([self.dut_exec_path + "\\WindowsApplicationDriver\\WinAppDriver.exe", self.dut_resolved_ip + " " + self.app_port + " /forcequit"], blocking=False)
-        logging.info("Creating Desktop Driver")
-        desired_caps = {}
-        desired_caps["app"] = "Root"
-        desktop = self._launchApp(desired_caps, track_driver=False)
-        desktop.implicitly_wait(10)
+        # Try to finish setup for built in teams.
+        else:
+            # First confirm the MSTeams Appx package is actually installed before
+            # we go poking at the taskbar / search bar. Without this check, typing
+            # "Microsoft Teams" into search on a device where Teams isn't installed
+            # would surface web suggestions and could launch Edge.
+            teams_pkg = self._call(
+                ["powershell.exe", "(Get-AppxPackage -Name MSTeams).PackageFullName"],
+                expected_exit_code=""
+            ).strip()
+
+            if not teams_pkg:
+                logging.info("MSTeams Appx package not installed on DUT, skipping built-in Teams launch.")
+            else:
+                logging.info(f"Found MSTeams Appx package: {teams_pkg}")
+                try:
+                    self.active_driver = desktop
+                    apps_elem = self._get_app_tray(desktop)
+
+                    id = "MSTeams"
+                    # Match any element whose AutomationId contains "MSTeams" so we
+                    # don't have to track the exact (and long/changing) full id.
+                    app_button = apps_elem.find_element_by_xpath(f"//*[contains(@AutomationId, '{id}')]")
+                    app_button.click()
+                    logging.info("Waiting for 'Finish setup' button...")
+                    finish_setup_btn = WebDriverWait(desktop, 60).until(EC.presence_of_element_located((By.XPATH, "//Button[contains(@Name, 'Finish setup')]")))
+                    finish_setup_btn.click()
+                    logging.info("Clicked 'Finish setup'.")
+                    time.sleep(180)
+                except:
+                    logging.info("Teams not found in taskbar, trying to launch via start menu search.")
+                    try:
+                        # Press Windows key, type "Microsoft Teams", and hit Enter to launch.
+                        # Safe to do here because we've already confirmed the package is installed,
+                        # so search will surface the app rather than a Bing/Store web suggestion.
+                        ActionChains(desktop).send_keys(Keys.META).perform()
+                        time.sleep(2)
+                        ActionChains(desktop).send_keys("Microsoft Teams").perform()
+                        time.sleep(2)
+                        ActionChains(desktop).send_keys(Keys.ENTER).perform()
+                        logging.info("Waiting for 'Finish setup' button...")
+                        finish_setup_btn = WebDriverWait(desktop, 60).until(EC.presence_of_element_located((By.XPATH, "//Button[contains(@Name, 'Finish setup')]")))
+                        finish_setup_btn.click()
+                        logging.info("Clicked 'Finish setup'.")
+                        time.sleep(180)
+                    except:
+                        try:
+                            logging.debug("Killing msedge in case it was launched because teams isn't installed.")
+                            self._kill("msedge.exe")
+                        except:
+                            pass
+                        logging.info("Failed to see 'Finish setup' button after launching Teams. Built in teams is already set up or needs to be installed. Will try to proceed with setup.")
 
         # Launch Settings to microphone/camera/location set permissions to teams true
         logging.info("Setting Permissions for Teams")


### PR DESCRIPTION
teams_install - added support for trying to setup built in teams seen on latest LKGs. If it can't locate it then it will attempt to continue with setup or will fail and user will need to run again with setting installing teams.

cinebench - added kill routine so it would close if scenario failed 

discharge - added taper workload functionality to stop workload earlier to let device cool down. Added support to prep tools if workload is set.