### PR TITLE
Fix mac_net_aspire (Rosetta 2) and mac_opencv_build (ffmpeg@6) failures

### DIFF
--- a/scenarios/macos/mac_net_aspire/mac_net_aspire.py
+++ b/scenarios/macos/mac_net_aspire/mac_net_aspire.py
@@ -14,7 +14,7 @@ import time
 class MacNetAspire(core.app_scenario.Scenario):
 
     module = __module__.split('.')[-1]
-    prep_version = "10"
+    prep_version = "11"
     resources = module + "_resources"
 
 

--- a/scenarios/macos/mac_net_aspire/mac_net_aspire_resources/mac_net_aspire_prep.sh
+++ b/scenarios/macos/mac_net_aspire/mac_net_aspire_resources/mac_net_aspire_prep.sh
@@ -71,6 +71,21 @@ else
     fi
 fi
 
+# Installing Rosetta 2
+# The Aspire build invokes grpc.tools' protoc, which Homebrew/NuGet ship only as
+# an x86_64 binary (tools/macosx_x64/protoc). On Apple Silicon without Rosetta 2
+# this fails with "Bad CPU type in executable" (Win32Exception 86) during the
+# ConfigurationSchema regeneration build. Rosetta lets the x86_64 protoc run
+# under emulation; protoc is a build-time codegen tool only and is not part of
+# the timed workload, so this does not affect benchmark results.
+log "-- Installing Rosetta 2"
+if /usr/bin/pgrep -q oahd; then
+    log "✓ Rosetta 2 already installed"
+else
+    sudo -A softwareupdate --install-rosetta --agree-to-license
+    check_status "Rosetta 2 installation"
+fi
+
 cd $BIN_DIR || {
     log " ERROR - Failed to change to $BIN_DIR"
     exit 1

--- a/scenarios/macos/mac_opencv_build/mac_opencv_build.py
+++ b/scenarios/macos/mac_opencv_build/mac_opencv_build.py
@@ -14,7 +14,7 @@ import time
 class MacOpencvBuild(core.app_scenario.Scenario):
 
     module = __module__.split('.')[-1]
-    prep_version = "6"
+    prep_version = "7"
     resources = module + "_resources"
 
 

--- a/scenarios/macos/mac_opencv_build/mac_opencv_build_resources/mac_opencv_build_prep.sh
+++ b/scenarios/macos/mac_opencv_build/mac_opencv_build_resources/mac_opencv_build_prep.sh
@@ -182,6 +182,13 @@ fi
 log "✓ libavcodec version resolved via pkg-config: $FFMPEG_VERSION"
 
 log "-- Creating build directory"
+# Force a clean CMake configuration. A stale CMakeCache.txt from a previous prep
+# (e.g. one generated before ffmpeg@6 pinning) caches the resolved FFmpeg paths,
+# so re-running cmake silently keeps the old ffmpeg (8.x) and breaks the
+# OpenCV 4.10 videoio compile with removed APIs like avcodec_close and
+# av_stream_get_side_data. Removing the build dir guarantees ffmpeg@6 is picked
+# up fresh via PKG_CONFIG_PATH below.
+rm -rf $BIN_DIR/build_opencv
 mkdir -p $BIN_DIR/build_opencv
 cd $BIN_DIR/build_opencv || {
     log " ERROR - Failed to change to build_opencv directory"

--- a/scenarios/macos/mac_opencv_build/mac_opencv_build_resources/mac_opencv_build_run.sh
+++ b/scenarios/macos/mac_opencv_build/mac_opencv_build_resources/mac_opencv_build_run.sh
@@ -108,6 +108,19 @@ check_command "cmake" || exit 1
 # Set BIN_DIR to /Users/Shared/hobl_bin
 BIN_DIR="/Users/Shared/hobl_bin"
 
+# Pin ffmpeg@6 for the build. The CMake cache produced during prep already
+# resolves FFmpeg to the keg-only ffmpeg@6 formula, but export PKG_CONFIG_PATH
+# here as well so any incremental CMake reconfigure triggered by `make` keeps
+# using ffmpeg@6 instead of Homebrew's rolling ffmpeg (8.x), whose removed APIs
+# (avcodec_close, av_stream_get_side_data) break OpenCV 4.10 videoio.
+FFMPEG6_PREFIX="$(/opt/homebrew/bin/brew --prefix ffmpeg@6 2>/dev/null)"
+if [ -n "$FFMPEG6_PREFIX" ] && [ -d "$FFMPEG6_PREFIX" ]; then
+    export PKG_CONFIG_PATH="$FFMPEG6_PREFIX/lib/pkgconfig:$PKG_CONFIG_PATH"
+    log "✓ Using ffmpeg@6 from: $FFMPEG6_PREFIX"
+else
+    log " ERROR - ffmpeg@6 prefix could not be resolved; build may pick up an incompatible ffmpeg"
+fi
+
 # Set Python version
 log "-- Setting Python version"
 pyenv global 3.12.10


### PR DESCRIPTION
## Summary

Two macOS developer scenarios were failing on Apple Silicon retest run. This PR root-causes both failures and ships targeted fixes. Both are Apple-Silicon environment issues.

| Scenario | Failure | Fix |
|---|---|---|
| `mac_net_aspire` | `Bad CPU type in executable` (Win32Exception 86) during build | Install Rosetta 2 in prep |
| `mac_opencv_build` | FFmpeg 8 API incompatibility breaks the OpenCV compile | Pin to `ffmpeg@6` + force a clean CMake configure |

---

## 1. `mac_net_aspire` — Rosetta 2 required for x86_64 `protoc`

### Root cause
The .NET Aspire build invokes `grpc.tools`' `protoc` during the `ConfigurationSchema` regeneration step. The NuGet/Homebrew `grpc.tools` package ships `protoc` **only as an x86_64 binary** (`tools/macosx_x64/protoc`) — there is no native arm64 build. On an Apple Silicon machine **without Rosetta 2 installed**, executing that binary fails with:

```
Bad CPU type in executable
```

surfaced by the build as `Win32Exception 86`. Older Macs in the fleet already had Rosetta installed (typically as a side effect of other software), which masked the dependency. The M5 came up clean, so the gap became visible.

### Fix
Add a Rosetta 2 install step to `mac_net_aspire_prep.sh`, after the Xcode Command Line Tools install and before `cd $BIN_DIR`:

```sh
# Installing Rosetta 2
log "-- Installing Rosetta 2"
if /usr/bin/pgrep -q oahd; then
    log "✓ Rosetta 2 already installed"
else
    sudo -A softwareupdate --install-rosetta --agree-to-license
    check_status "Rosetta 2 installation"
fi
```

- Detection uses `pgrep oahd` (the Rosetta daemon) so the install is skipped when Rosetta is already present.
- Uses the existing `sudo -A` / `SUDO_ASKPASS` mechanism for non-interactive auth — no prompt during a lab run.

### Why this does not affect benchmark validity
`protoc` is a **build-time code-generation tool** only. It runs during prep/build, not during the timed workload, so running it under Rosetta emulation has no impact on the measured `scenario_runtime` or any reported metric.

### prep_version
Bumped `prep_version` `"10"` → `"11"` in `mac_net_aspire.py`. **Required** because existing DUTs without Rosetta must re-run prep for the fix to take effect.

---

## 2. `mac_opencv_build` — FFmpeg 8 API incompatibility

### Root cause
Homebrew's default `ffmpeg` formula had moved to **8.1.1**. OpenCV 4.10's `modules/videoio/src/cap_ffmpeg_impl.hpp` still uses FFmpeg APIs that were **removed in FFmpeg 8**, including `avcodec_close` and `av_stream_get_side_data`. Compiling OpenCV against FFmpeg 8 therefore fails. Additionally, a **stale `CMakeCache.txt`** in the build directory was pinning the previously-detected FFmpeg 8 paths, so even after installing a compatible FFmpeg the configure step kept resolving the wrong version.

### Fix
1. **Pin the runtime/build to `ffmpeg@6`** — `mac_opencv_build_run.sh` now resolves the `ffmpeg@6` prefix and prepends it to `PKG_CONFIG_PATH` before `make`, so CMake/pkg-config discovers a compatible FFmpeg:

   ```sh
   FFMPEG6_PREFIX="$(/opt/homebrew/bin/brew --prefix ffmpeg@6 2>/dev/null)"
   if [ -n "$FFMPEG6_PREFIX" ] && [ -d "$FFMPEG6_PREFIX" ]; then
       export PKG_CONFIG_PATH="$FFMPEG6_PREFIX/lib/pkgconfig:$PKG_CONFIG_PATH"
       log "✓ Using ffmpeg@6 from: $FFMPEG6_PREFIX"
   else
       log " ERROR - ffmpeg@6 prefix could not be resolved; build may pick up an incompatible ffmpeg"
   fi
   ```

2. **Force a clean CMake configure** — `mac_opencv_build_prep.sh` now removes the build directory before re-creating it, so a stale `CMakeCache.txt` can't pin the wrong FFmpeg:

   ```sh
   rm -rf $BIN_DIR/build_opencv
   mkdir -p $BIN_DIR/build_opencv
   ```

   (Prep already installs the correct toolchain via `brew install cmake ffmpeg@6` and sets the `ffmpeg@6` `PKG_CONFIG_PATH` during configure.)

### prep_version
Bumped `prep_version` `"6"` → `"7"` in `mac_opencv_build.py`. **Required** because existing DUTs need the clean-configure step to re-run and clear the stale cache.

---

## Files changed

```
scenarios/macos/mac_net_aspire/mac_net_aspire.py                                  (prep_version 10 → 11)
scenarios/macos/mac_net_aspire/mac_net_aspire_resources/mac_net_aspire_prep.sh    (+ Rosetta 2 install)
scenarios/macos/mac_opencv_build/mac_opencv_build.py                              (prep_version 6 → 7)
scenarios/macos/mac_opencv_build/mac_opencv_build_resources/mac_opencv_build_prep.sh  (+ clean build dir)
scenarios/macos/mac_opencv_build/mac_opencv_build_resources/mac_opencv_build_run.sh   (+ ffmpeg@6 PKG_CONFIG_PATH)
```

## Testing / validation

- [X] Run `mac_net_aspire` prep + run on an Apple Silicon Mac **without** Rosetta; confirm prep installs Rosetta and the build completes.
  - Verify: `pgrep oahd` returns a PID, and `arch -x86_64 /usr/bin/true` succeeds.
- [X] Run `mac_opencv_build` prep + run on a DUT that previously failed; confirm a clean configure picks up `ffmpeg@6` and the OpenCV build completes.
  - Verify the run log shows `✓ Using ffmpeg@6 from: ...`.
- [X] Confirm `scenario_runtime` is reported for both scenarios.

## Notes
- Both `prep_version` bumps are intentional: each change must re-execute on existing DUTs (Rosetta install / clean reconfigure), per the repo's prep-version policy.
- Error messages follow the repo convention (` ERROR - `).
- No teardown changes; prep-installed artifacts are preserved.
