### PR TITLE
ollama: custom-zip support, native binary on macOS, better diagnostics

### DIFF
--- a/scenarios/macos/mac_ollama/mac_ollama.py
+++ b/scenarios/macos/mac_ollama/mac_ollama.py
@@ -14,7 +14,7 @@ import time
 class MacNodejs(core.app_scenario.Scenario):
 
     module = __module__.split('.')[-1]
-    prep_version = "5"
+    prep_version = "7"
     resources = module + "_resources"
 
 

--- a/scenarios/macos/mac_ollama/mac_ollama_resources/mac_ollama_prep.sh
+++ b/scenarios/macos/mac_ollama/mac_ollama_resources/mac_ollama_prep.sh
@@ -18,12 +18,20 @@ log() {
     echo "$1" >> "$LOG_FILE"
 }
 
+check() {
+    if [ $1 -ne 0 ]; then
+        log " ERROR - Last command failed with exit code: $1"
+        exit $1
+    fi
+}
+
 # Initialize log file
 echo "-- ollama prep started" > "$LOG_FILE"
 
 log "-- ollama prep started"
 
 log "-- Installing XCode tools"
+# xcode-select --install returns non-zero when CLT is already present; ignore rc.
 xcode-select --install
 
 if [ ! -d "$BIN_DIR" ]; then
@@ -35,10 +43,21 @@ log "-- Changing to $BIN_DIR"
 cd $BIN_DIR
 
 log "-- Cloning repo"
-git clone https://github.com/ollama/ollama.git
+if [ -d "$BIN_DIR/ollama/.git" ]; then
+    log "-- ollama repo already present at $BIN_DIR/ollama; reusing existing clone"
+else
+    if [ -e "$BIN_DIR/ollama" ]; then
+        log " ERROR - $BIN_DIR/ollama exists but is not a git repo; remove it manually and re-prep"
+        exit 1
+    fi
+    git clone https://github.com/ollama/ollama.git
+    check $?
+fi
 cd $BIN_DIR/ollama
-log "-- Checkout version 0.12.1"
-git checkout v0.12.1
+log "-- Checkout version 0.20.8-rc0"
+git fetch --tags --quiet
+git checkout v0.20.8-rc0
+check $?
 
 log "-- Install Brew"
 export NONINTERACTIVE=1
@@ -47,6 +66,7 @@ eval "$(/opt/homebrew/bin/brew shellenv)"
 
 log "-- Install go"
 brew install go@1.25
+check $?
 
 # go@1.25 is keg-only and not symlinked into /opt/homebrew, add to PATH
 export PATH="/opt/homebrew/opt/go@1.25/bin:$PATH"
@@ -64,6 +84,18 @@ fi
 log "-- Download modules"
 cd $BIN_DIR/ollama
 go mod tidy
+check $?
+
+log "-- Building ollama binary"
+cd $BIN_DIR/ollama
+go build -o ollama .
+check $?
+if [ ! -x "$BIN_DIR/ollama/ollama" ]; then
+    log " ERROR - go build completed but $BIN_DIR/ollama/ollama was not produced"
+    exit 1
+fi
+log "-- Built ollama at: $BIN_DIR/ollama/ollama"
+./ollama --version 2>&1 | while IFS= read -r line; do log "ollama: $line"; done
 
 log "-- ollama prep completed"
 exit 0

--- a/scenarios/macos/mac_ollama/mac_ollama_resources/mac_ollama_run.sh
+++ b/scenarios/macos/mac_ollama/mac_ollama_resources/mac_ollama_run.sh
@@ -43,6 +43,13 @@ eval "$(/opt/homebrew/bin/brew shellenv)" 2>/dev/null || true
 
 cd $BIN_DIR/ollama
 
+OLLAMA_BIN="$BIN_DIR/ollama/ollama"
+if [ ! -x "$OLLAMA_BIN" ]; then
+    log " ERROR - $OLLAMA_BIN missing or not executable. Prep did not complete."
+    log " ERROR - Re-prep required: delete the prep_status file for mac_ollama on the DUT and re-run."
+    exit 1
+fi
+
 # Disable progress indicator
 export NO_COLOR=1
 
@@ -52,7 +59,7 @@ VERBOSE_LOG="$LOG_DIR/mac_ollama_verbose.log"
 log "-- Run $MODEL model with prompt"
 log "-- Script log: $LOG_FILE"
 log "-- Verbose output: $VERBOSE_LOG"
-go run . run $MODEL "what is the meaning of life?" --verbose > $VERBOSE_LOG 2>&1
+"$OLLAMA_BIN" run $MODEL "what is the meaning of life?" --verbose > $VERBOSE_LOG 2>&1
 check $?
 
 log "-- Parsing metrics from verbose log file"

--- a/scenarios/macos/mac_ollama/mac_ollama_resources/mac_ollama_setup.sh
+++ b/scenarios/macos/mac_ollama/mac_ollama_resources/mac_ollama_setup.sh
@@ -17,6 +17,13 @@ log() {
     echo "$1" >> "$LOG_FILE"
 }
 
+check() {
+    if [ $1 -ne 0 ]; then
+        log " ERROR - Last command failed with exit code: $1"
+        exit $1
+    fi
+}
+
 # Initialize log file
 echo "-- ollama setup started" > "$LOG_FILE"
 
@@ -34,15 +41,21 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-log "-- Building ollama"
-go run main.go
-if [ $? -ne 0 ]; then
-    log " ERROR - Last command failed."
+OLLAMA_BIN="$BIN_DIR/ollama/ollama"
+if [ ! -x "$OLLAMA_BIN" ]; then
+    log " ERROR - $OLLAMA_BIN missing or not executable. Prep did not complete."
+    log " ERROR - Re-prep required: delete the prep_status file for mac_ollama on the DUT and re-run."
     exit 1
 fi
+log "-- Using ollama binary: $OLLAMA_BIN"
+"$OLLAMA_BIN" --version 2>&1 | while IFS= read -r line; do log "ollama: $line"; done
 
 log "-- Launching server in background"
-nohup go run . serve > /dev/null 2>&1 &
+SERVER_LOG="$LOG_DIR/mac_ollama_server.log"
+: > "$SERVER_LOG"
+nohup "$OLLAMA_BIN" serve > "$SERVER_LOG" 2>&1 &
+SERVER_PID=$!
+log "-- Server PID: $SERVER_PID  (stdout/stderr -> $SERVER_LOG)"
 
 log "-- Waiting for server to be ready..."
 max_attempts=30
@@ -52,7 +65,14 @@ server_ready=false
 while [ $attempt -lt $max_attempts ] && [ "$server_ready" = "false" ]; do
     attempt=$((attempt + 1))
     sleep 1
-    
+
+    # Fail fast if the server process died (crash on startup: port in use,
+    # permission issues, GPU init failure, etc.).
+    if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+        log " ERROR - ollama serve process (pid $SERVER_PID) exited after $attempt seconds"
+        exit 1
+    fi
+
     # Try to connect to ollama's default endpoint
     if curl -s -o /dev/null -w "%{http_code}" "http://localhost:11434/api/tags" | grep -q "200"; then
         server_ready=true
@@ -68,10 +88,8 @@ if [ "$server_ready" = "false" ]; then
 fi
 
 log "-- Pulling gemma3"
-go run . pull gemma3
-if [ $? -ne 0 ]; then
-    log " ERROR - Last command failed."
-    exit 1
-fi
+PULL_LOG="$LOG_DIR/mac_ollama_pull.log"
+"$OLLAMA_BIN" pull gemma3 > "$PULL_LOG" 2>&1
+check $?
 
 exit 0

--- a/scenarios/macos/mac_ollama/mac_ollama_resources/mac_ollama_teardown.sh
+++ b/scenarios/macos/mac_ollama/mac_ollama_resources/mac_ollama_teardown.sh
@@ -15,17 +15,19 @@ log() {
 echo "-- mac_ollama_teardown.sh started $(date)" > "$LOG_FILE"
 log "-- ollama teardown started"
 
-# Stop the Ollama server (go process)
-log "-- Stopping Ollama server (go processes)"
+# Stop the Ollama server (built binary; legacy go-run pattern as fallback)
+log "-- Stopping Ollama server"
+pkill -f "$BIN_DIR/ollama/ollama serve" 2>/dev/null
 pkill -f "go run . serve" 2>/dev/null
-pkill -f "ollama" 2>/dev/null
+pkill -x ollama 2>/dev/null
 
 # Give processes a moment to exit
 sleep 2
 
 # Verify server is stopped
-if pgrep -f "go run . serve" > /dev/null 2>&1; then
-    log "-- Force killing remaining go processes"
+if pgrep -f "$BIN_DIR/ollama/ollama serve" > /dev/null 2>&1 || pgrep -f "go run . serve" > /dev/null 2>&1; then
+    log "-- Force killing remaining ollama processes"
+    pkill -9 -f "$BIN_DIR/ollama/ollama serve" 2>/dev/null
     pkill -9 -f "go run . serve" 2>/dev/null
 fi
 

--- a/scenarios/windows/ollama/ollama.py
+++ b/scenarios/windows/ollama/ollama.py
@@ -20,12 +20,16 @@ class Ollama(core.app_scenario.Scenario):
 
     # Set default parameters
     Params.setDefault(module, 'loops', '1')
+    Params.setDefault(module, 'use_custom_ollama', 'false', valOptions=["true", "false"])
+    Params.setDefault(module, 'custom_resources_path', '')
 
 
     def setUp(self):
         # Get parameters
         self.platform = Params.get('global', 'platform')
         self.loops = Params.get(self.module, 'loops')
+        self.use_custom_ollama = Params.get(self.module, 'use_custom_ollama').lower() == 'true'
+        self.custom_resources_path = Params.get(self.module, 'custom_resources_path')
 
         self.target = f"{self.dut_exec_path}\\{self.resources}"
 
@@ -37,10 +41,31 @@ class Ollama(core.app_scenario.Scenario):
             logging.info(f"Uploading test files to {self.target}")
             self._upload(f"scenarios\\windows\\{self.module}\\{self.resources}", self.dut_exec_path)
 
+            # Upload custom resources (ollama zip) to the DUT
+            if self.custom_resources_path:
+                if not os.path.isdir(self.custom_resources_path):
+                    logging.error(f"Custom resources path not found: {self.custom_resources_path}")
+                    raise FileNotFoundError(f"Custom resources path not found: {self.custom_resources_path}")
+                logging.info(f"Uploading custom resources from {self.custom_resources_path} to {self.dut_exec_path}")
+                self._upload(self.custom_resources_path, self.dut_exec_path)
+                folder_name = os.path.basename(self.custom_resources_path)
+                self.custom_resources_dut_path = f"{self.dut_exec_path}\\{folder_name}"
+            else:
+                self.custom_resources_dut_path = ""
+
+            # Validate combinations on host before invoking prep on the DUT
+            if self.use_custom_ollama and not self.custom_resources_dut_path:
+                raise ValueError("use_custom_ollama=true requires custom_resources_path to point to a folder containing the ollama-windows-*.zip")
+
             # Excute prep script
             logging.info("Executing prep, this make take 10-15 minutes...")
+            prep_cmd = f"{self.target}\\{self.module}_prep.ps1"
+            if self.custom_resources_dut_path:
+                prep_cmd += f' -customResourcesPath "{self.custom_resources_dut_path}"'
+            if self.use_custom_ollama:
+                prep_cmd += " -useCustomOllama"
             try:
-                self._call(["pwsh", f"{self.target}\\{self.module}_prep.ps1"], timeout=3600)
+                self._call(["pwsh", prep_cmd], timeout=3600)
             finally:
                 self._copy_data_from_remote(self.result_dir)
             self.createPrepStatusControlFile(self.prep_version)
@@ -74,9 +99,10 @@ class Ollama(core.app_scenario.Scenario):
 
     def kill(self):
         try:
-            logging.debug("Killing powershell and go")
+            logging.debug("Killing powershell, go, and ollama")
             self._kill("pwsh.exe")
             self._kill("go.exe")
+            self._kill("ollama.exe")
         except:
             pass
 

--- a/scenarios/windows/ollama/ollama_resources/ollama_prep.ps1
+++ b/scenarios/windows/ollama/ollama_resources/ollama_prep.ps1
@@ -2,7 +2,9 @@
 # Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 param(
-    [string]$logFile = ""
+    [string]$logFile = "",
+    [string]$customResourcesPath = "",
+    [switch]$useCustomOllama = $false
 )
 
 $scriptDrive = Split-Path -Qualifier $PSScriptRoot
@@ -15,6 +17,12 @@ if (-not (Test-Path "$scriptDrive\hobl_bin")) {
     Exit 1
 }
 if (-not $logFile) { $logFile = "$scriptDrive\hobl_data\ollama_prep.log" }
+
+# Set execution policy for current process (required for Expand-Archive on fresh installs)
+$executionPolicy = Get-ExecutionPolicy -Scope Process
+if ($executionPolicy -eq "Restricted" -or $executionPolicy -eq "Undefined") {
+    Set-ExecutionPolicy -ExecutionPolicy Unrestricted -Scope Process -Force -ErrorAction Stop
+}
 
 # Require PowerShell > 7
 $required = [version]"7.0"
@@ -39,14 +47,14 @@ if ($arch -eq "64-bit" -and $processorArch -eq "AMD64") {
     $isARM64 = $false
     $vsArchParam = "x64"
     $vsHostArchParam = "x64"
-    $logSuffix = "x64"
+    $logSuffix = if ($useCustomOllama) { "x64_Custom" } else { "x64" }
     $vsInstallPath = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\2022"
     $vsProduct = "BuildTools"
 } elseif ($arch -match "ARM" -or $processorArch -match "ARM") {
     $isARM64 = $true
     $vsArchParam = "arm64"
     $vsHostArchParam = "arm64"
-    $logSuffix = "ARM64"
+    $logSuffix = if ($useCustomOllama) { "ARM64_Custom" } else { "ARM64" }
     $vsInstallPath = "${env:ProgramFiles}\Microsoft Visual Studio\2022"
     $vsProduct = "Community"
 } else {
@@ -403,6 +411,127 @@ set
 Set-Content -Path $logFile -encoding utf8 "-- ollama prep started ($logSuffix version)"
 
 "Detected architecture: $arch (Processor: $processorArch)" | log
+if ($useCustomOllama) { "Mode: CUSTOM (use pre-built ollama.exe from zip; skip Go/VS/CMake/LLVM/git build chain)" | log }
+if ($customResourcesPath) { "Custom resources path: $customResourcesPath" | log }
+
+# ============================================================================
+# Validate custom-resources inputs early so we fail fast with a clear message
+# instead of part-way through download / install steps.
+# ============================================================================
+if ($useCustomOllama) {
+    if (-not $customResourcesPath) {
+        " ERROR - -useCustomOllama requires -customResourcesPath to be supplied." | log
+        Exit 1
+    }
+    if (-not (Test-Path $customResourcesPath)) {
+        " ERROR - customResourcesPath does not exist on the DUT: $customResourcesPath" | log
+        Exit 1
+    }
+    "Contents of customResourcesPath ($customResourcesPath):" | log
+    Get-ChildItem -Path $customResourcesPath -File | ForEach-Object {
+        "  $($_.Name) ($([math]::Round($_.Length / 1MB, 1)) MB)" | log
+    }
+}
+
+# ============================================================================
+# Custom-Ollama path: extract pre-built ollama-windows-*.zip into $scriptDrive\hobl_bin\ollama.
+# No Go, no Visual Studio, no CMake, no LLVM-MinGW, no git clone, no compile.
+# ============================================================================
+if ($useCustomOllama) {
+    "-- Custom Ollama path: extracting pre-built binary" | log
+
+    $expectedZipPattern = if ($isARM64) { "ollama-windows-arm64*.zip" } else { "ollama-windows-amd64*.zip" }
+    $ollamaZip = Get-ChildItem -Path $customResourcesPath -Filter $expectedZipPattern | Select-Object -First 1
+    if (-not $ollamaZip) {
+        # Fall back to any ollama-windows-*.zip so a generically-named zip still works,
+        # but log which one we picked.
+        $ollamaZip = Get-ChildItem -Path $customResourcesPath -Filter "ollama-windows-*.zip" | Select-Object -First 1
+        if ($ollamaZip) {
+            " WARNING - No $expectedZipPattern found; falling back to $($ollamaZip.Name). Verify it matches the DUT architecture ($logSuffix)." | log
+        }
+    }
+    if (-not $ollamaZip) {
+        " ERROR - No ollama-windows-*.zip found in: $customResourcesPath" | log
+        " ERROR - Expected file name pattern: $expectedZipPattern" | log
+        Exit 1
+    }
+    "Found ollama zip: $($ollamaZip.Name) ($([math]::Round($ollamaZip.Length / 1MB, 1)) MB)" | log
+
+    $ollamaInstallDir = "$scriptDrive\hobl_bin\ollama"
+    if (Test-Path $ollamaInstallDir) {
+        "Removing existing $ollamaInstallDir to ensure clean extraction..." | log
+        try {
+            Remove-Item -Recurse -Force $ollamaInstallDir -ErrorAction Stop
+        } catch {
+            " ERROR - Failed to clean $ollamaInstallDir : $($_.Exception.Message)" | log
+            " ERROR - Close any process holding files in that directory (ollama.exe?) and retry." | log
+            Exit 1
+        }
+    }
+    New-Item -ItemType Directory -Path $ollamaInstallDir -Force | Out-Null
+
+    "Extracting $($ollamaZip.FullName) -> $ollamaInstallDir ..." | log
+    try {
+        Expand-Archive -Path $ollamaZip.FullName -DestinationPath $ollamaInstallDir -Force -ErrorAction Stop
+    } catch {
+        " ERROR - Failed to extract ollama zip: $($_.Exception.Message)" | log
+        Exit 1
+    }
+
+    # Zip layouts vary:
+    #   - flat:    ollama.exe at root, libs in lib\ollama\
+    #   - nested:  ollama-windows-amd64\ollama.exe (older releases, single top-level folder)
+    #   - app/:    app\ollama.exe alongside its DLLs (current Windows release layout)
+    # Promote a single top-level folder, but leave the app\ subfolder intact since
+    # ollama.exe depends on the DLLs that ship next to it there.
+    $ollamaExePath = Join-Path $ollamaInstallDir "ollama.exe"
+    $ollamaExeAppPath = Join-Path $ollamaInstallDir "app\ollama.exe"
+    if (-not (Test-Path $ollamaExePath) -and -not (Test-Path $ollamaExeAppPath)) {
+        $nested = Get-ChildItem -Path $ollamaInstallDir -Directory | Where-Object {
+            (Test-Path (Join-Path $_.FullName "ollama.exe")) -or
+            (Test-Path (Join-Path $_.FullName "app\ollama.exe"))
+        } | Select-Object -First 1
+        if ($nested) {
+            "Zip contained a top-level folder ($($nested.Name)); flattening..." | log
+            Get-ChildItem -Path $nested.FullName -Force | ForEach-Object {
+                Move-Item -Path $_.FullName -Destination $ollamaInstallDir -Force
+            }
+            Remove-Item -Recurse -Force $nested.FullName -ErrorAction SilentlyContinue
+        }
+    }
+
+    if (Test-Path $ollamaExeAppPath) {
+        $ollamaExePath = $ollamaExeAppPath
+    }
+
+    if (-not (Test-Path $ollamaExePath)) {
+        " ERROR - ollama.exe not found at $ollamaInstallDir (checked root and app\) after extraction." | log
+        "Extracted contents:" | log
+        Get-ChildItem -Path $ollamaInstallDir -Recurse -Depth 2 | ForEach-Object {
+            "  $($_.FullName)" | log
+        }
+        Exit 1
+    }
+    "ollama.exe present at: $ollamaExePath" | log
+
+    # Verify the binary actually runs and report version into the log so future
+    # failure triage knows exactly which build was used.
+    "-- Verifying ollama.exe --version" | log
+    $ollamaVersionOutput = & $ollamaExePath --version 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        " ERROR - 'ollama.exe --version' exited $LASTEXITCODE" | log
+        $ollamaVersionOutput | ForEach-Object { "  $_" | log }
+        Exit 1
+    }
+    $ollamaVersionOutput | ForEach-Object { "ollama: $_" | log }
+
+    "-- ollama prep completed ($logSuffix version - custom binary)" | log
+    Exit 0
+}
+
+# ============================================================================
+# Default path below: install Go + VS + CMake + LLVM-MinGW, clone, and build.
+# ============================================================================
 "Using Visual Studio $vsProduct for $logSuffix" | log
 
 "-- Installing GoLang 1.25.1" | log
@@ -533,22 +662,22 @@ if (Test-Path $llvmZipPath) {
 }
 
 "-- Cloning git repo" | log
-checkSetLocation "$scriptDrive\"
+checkSetLocation "$scriptDrive\hobl_bin\"
 git clone https://github.com/ollama/ollama.git
-checkGitClone $lastexitcode "$scriptDrive\ollama"
+checkGitClone $lastexitcode "$scriptDrive\hobl_bin\ollama"
 
 "-- Checkout" | log
-checkSetLocation "$scriptDrive\ollama"
-git checkout v0.12.1
+checkSetLocation "$scriptDrive\hobl_bin\ollama"
+git checkout v0.20.8-rc0
 check($lastexitcode)
 
 if (-not $isARM64) {
-    "-- Configuring Ollama (x64 only)" | log
-    checkSetLocation "$scriptDrive\ollama"
+    "-- Configuring discrete-GPU runners (x64 only)" | log
+    checkSetLocation "$scriptDrive\hobl_bin\ollama"
     cmake -B build
     check($lastexitcode)
 } else {
-    "-- Skipping Ollama configuration (not supported on ARM64)" | log
+    "-- Skipping cmake configure on ARM64 (no discrete-GPU runners; CPU/Vulkan inference is built into ollama.exe by go build + MinGW)" | log
 }
 
 "-- Download modules" | log
@@ -556,12 +685,23 @@ go mod tidy
 check($lastexitcode)
 
 if (-not $isARM64) {
-    "-- Building Ollama (x64 only)" | log
+    "-- Building discrete-GPU runners (x64 only)" | log
     cmake --build build
     check($lastexitcode)
 } else {
-    "-- Skipping Ollama build (not supported on ARM64)" | log
+    "-- Skipping cmake build on ARM64 (no discrete-GPU runners; CPU/Vulkan inference is built into ollama.exe by go build + MinGW)" | log
 }
+
+"-- Building ollama.exe" | log
+checkSetLocation "$scriptDrive\hobl_bin\ollama"
+go build -o ollama.exe .
+check($lastexitcode)
+if (-not (Test-Path "$scriptDrive\hobl_bin\ollama\ollama.exe")) {
+    " ERROR - go build completed but $scriptDrive\hobl_bin\ollama\ollama.exe was not produced." | log
+    Exit 1
+}
+"Built ollama.exe at: $scriptDrive\hobl_bin\ollama\ollama.exe" | log
+& "$scriptDrive\hobl_bin\ollama\ollama.exe" --version 2>&1 | ForEach-Object { "ollama: $_" | log }
 
 "-- ollama prep completed ($logSuffix version)" | log
 Exit 0

--- a/scenarios/windows/ollama/ollama_resources/ollama_run.ps1
+++ b/scenarios/windows/ollama/ollama_resources/ollama_run.ps1
@@ -112,20 +112,21 @@ Write-RunPhaseMarker "phase.run_prep.start"
 
 $Env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
 
-# Verify required commands are findable on PATH after refresh.
-# Fail fast with a clear diagnostic instead of a chain of "term not recognized" errors.
-foreach ($cmd in @('go')) {
-    $resolved = Get-Command $cmd -ErrorAction SilentlyContinue
-    if (-not $resolved) {
-        " ERROR - Required command '$cmd' not found on PATH after refresh." | log
-        " ERROR - Prep may not have completed, or the RPC service has a stale PATH." | log
-        " ERROR - PATH: $env:Path" | log
+# Source-built ollama lives at ollama\ollama.exe; custom-zip releases ship it at ollama\app\ollama.exe.
+$ollamaExe = "$scriptDrive\hobl_bin\ollama\ollama.exe"
+if (-not (Test-Path $ollamaExe)) {
+    $ollamaExeApp = "$scriptDrive\hobl_bin\ollama\app\ollama.exe"
+    if (Test-Path $ollamaExeApp) {
+        $ollamaExe = $ollamaExeApp
+    } else {
+        " ERROR - ollama.exe missing at both $ollamaExe and $ollamaExeApp. Prep did not complete." | log
+        " ERROR - Re-prep required: delete $scriptDrive\hobl_bin\prep_status\ollama<version> on the DUT and re-run." | log
         Exit 1
     }
-    "Found ${cmd}: $($resolved.Source)" | log
 }
+"Using ollama binary: $ollamaExe" | log
 
-Set-Location "$scriptDrive\ollama"
+Set-Location "$scriptDrive\hobl_bin\ollama"
 
 # Disable Progress indicator
 $env:NO_COLOR = "1"
@@ -138,7 +139,7 @@ $verboseLog = Join-Path (Split-Path $logFile -Parent) "ollama_verbose_$($logSuff
 "-- Verbose output: $verboseLog" | log
 Write-RunPhaseMarker "phase.run_prep.end"
 Write-RunPhaseMarker "phase.run_build.start"
-go run . run $model "what is the meaning of life?" --verbose > $verboseLog 2>&1
+& $ollamaExe run $model "what is the meaning of life?" --verbose > $verboseLog 2>&1
 check($lastexitcode)
 Write-RunPhaseMarker "phase.run_build.end"
 Write-RunPhaseMarker "phase.run_results.start"

--- a/scenarios/windows/ollama/ollama_resources/ollama_setup.ps1
+++ b/scenarios/windows/ollama/ollama_resources/ollama_setup.ps1
@@ -54,15 +54,29 @@ function checkSetLocation {
 }
 
 Set-Content -Path $logFile -encoding utf8 "-- ollama setup started"
+"-- ollama setup started" | log
 
 $Env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
 
-checkSetLocation "$scriptDrive\ollama"
+checkSetLocation "$scriptDrive\hobl_bin\ollama"
+
+# Source-built ollama lives at ollama\ollama.exe; custom-zip releases ship it at ollama\app\ollama.exe.
+$ollamaExe = "$scriptDrive\hobl_bin\ollama\ollama.exe"
+if (-not (Test-Path $ollamaExe)) {
+    $ollamaExeApp = "$scriptDrive\hobl_bin\ollama\app\ollama.exe"
+    if (Test-Path $ollamaExeApp) {
+        $ollamaExe = $ollamaExeApp
+    } else {
+        " ERROR - ollama.exe missing at both $ollamaExe and $ollamaExeApp. Prep did not complete." | log
+        " ERROR - Re-prep required: delete $scriptDrive\hobl_bin\prep_status\ollama<version> on the DUT and re-run." | log
+        Exit 1
+    }
+}
+"Using ollama binary: $ollamaExe" | log
 
 # Clean up any existing Ollama processes before starting
 "-- Stopping any existing Ollama processes..." | log
 
-# Kill ollama.exe processes
 $ollamaProcesses = Get-Process -Name "ollama" -ErrorAction SilentlyContinue
 if ($ollamaProcesses) {
     "-- Found existing ollama.exe processes, terminating..." | log
@@ -71,7 +85,6 @@ if ($ollamaProcesses) {
     "-- No ollama.exe processes running..." | log
 }
 
-# Also check for ollama_llama_server or related processes
 $llamaProcesses = Get-Process -Name "*ollama*" -ErrorAction SilentlyContinue
 if ($llamaProcesses) {
     $llamaProcesses | ForEach-Object {
@@ -84,24 +97,31 @@ if ($llamaProcesses) {
     "-- No ollama_llama_server processes running..." | log
 }
 
-# Kill go.exe processes
-$goProcesses = Get-Process -Name "go" -ErrorAction SilentlyContinue
-if ($goProcesses) {
-    "-- Found existing go.exe processes, terminating..." | log
-    Stop-Process -Name "go" -Force -ErrorAction SilentlyContinue
-} else {
-    "-- No go.exe processes running..." | log
-}
-
-# Give processes time to terminate
 Start-Sleep -Seconds 2
 
-"-- Building ollama" | log
-go run main.go
-check($lastexitcode)
+# Capture the server's stdout/stderr to a file so server-side failures (model
+# load errors, GPU runner crashes, port-in-use, etc.) are diagnosable after
+# the scenario finishes.
+$serverStdOut = Join-Path $logDir "ollama_server_stdout.log"
+$serverStdErr = Join-Path $logDir "ollama_server_stderr.log"
+"-- Server stdout redirected to: $serverStdOut" | log
+"-- Server stderr redirected to: $serverStdErr" | log
 
-"-- Launching server in background" | log
-start-process go.exe -ArgumentList "run . serve" -WindowStyle Hidden
+"-- Verifying ollama.exe --version" | log
+$ollamaVersionOutput = & $ollamaExe --version 2>&1
+if ($LASTEXITCODE -ne 0) {
+    " ERROR - 'ollama.exe --version' exited $LASTEXITCODE" | log
+    $ollamaVersionOutput | ForEach-Object { "  $_" | log }
+    Exit 1
+}
+$ollamaVersionOutput | ForEach-Object { "ollama: $_" | log }
+
+"-- Launching ollama server in background ($ollamaExe serve)" | log
+Start-Process -FilePath $ollamaExe `
+    -ArgumentList "serve" `
+    -WindowStyle Hidden `
+    -RedirectStandardOutput $serverStdOut `
+    -RedirectStandardError $serverStdErr
 
 "-- Waiting for server to be ready..." | log
 $maxAttempts = 30
@@ -113,7 +133,6 @@ while ($attempt -lt $maxAttempts -and -not $serverReady) {
     Start-Sleep -Seconds 1
     
     try {
-        # Try to connect to ollama's default endpoint
         $response = Invoke-WebRequest -Uri "http://localhost:11434/api/tags" -Method GET -TimeoutSec 10 -ErrorAction Stop
         if ($response.StatusCode -eq 200) {
             $serverReady = $true
@@ -126,11 +145,12 @@ while ($attempt -lt $maxAttempts -and -not $serverReady) {
 
 if (-not $serverReady) {
     " ERROR - Server did not start within $maxAttempts seconds" | log
+    " ERROR - See $serverStdOut / $serverStdErr for the server's own output." | log
     Exit 1
 }
 
 "-- Pulling gemma3" | log
-go run . pull gemma3
+& $ollamaExe pull gemma3
 check($lastexitcode)
 
 Exit 0

--- a/scenarios/windows/ollama/ollama_resources/ollama_teardown.ps1
+++ b/scenarios/windows/ollama/ollama_resources/ollama_teardown.ps1
@@ -42,7 +42,7 @@ if ($arch -eq "64-bit" -and $processorArch -eq "AMD64") {
 $logFile = $logFile -replace "\.log$", "_$($logSuffix.ToLower()).log"
 
 # Ollama source directory
-$ollamaDir = "$scriptDrive\ollama"
+$ollamaDir = "$scriptDrive\hobl_bin\ollama"
 
 function log {
     [CmdletBinding()] Param([Parameter(ValueFromPipeline)] $msg)
@@ -56,32 +56,30 @@ function log {
     }
 }
 
-# Refresh PATH to ensure go is available
+# Refresh PATH so ollama is findable
 $Env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
 
+"-- ollama teardown started (arch=$logSuffix)" | log
+
+$ollamaExe = "$ollamaDir\ollama.exe"
+
 # ============================================================================
-# Step 1: Remove the gemma3 model using go run
+# Step 1: Remove the gemma3 model via ollama.exe
 # ============================================================================
 "Step 1: Removing gemma3 model..." | log
 
 try {
-    if (Test-Path $ollamaDir) {
-        Push-Location $ollamaDir
-        
-        # List current models before removal
+    if (Test-Path $ollamaExe) {
         "Current models:" | log
-        $models = & go run . list 2>&1
+        $models = & $ollamaExe list 2>&1
         $models | ForEach-Object { "  $_" | log }
-        
-        # Remove gemma3 model
-        "Removing gemma3 model via 'go run . rm gemma3'..." | log
-        $result = & go run . rm gemma3 2>&1
+
+        "Removing gemma3 model via '$ollamaExe rm gemma3'..." | log
+        $result = & $ollamaExe rm gemma3 2>&1
         $result | ForEach-Object { "  $_" | log }
         "gemma3 model removal attempted" | log
-        
-        Pop-Location
     } else {
-        "Ollama source directory not found at $ollamaDir, skipping model removal" | log
+        "$ollamaExe missing; skipping model removal (data dir will still be deleted below)" | log
     }
 } catch {
     "Warning: Failed to remove gemma3 model: $_" | log
@@ -116,31 +114,11 @@ try {
     "Warning: Failed to kill ollama processes: $_" | log
 }
 
-# ============================================================================
-# Step 3: Kill go.exe process (started the ollama server)
-# ============================================================================
-"Step 3: Killing go.exe process..." | log
-
-try {
-    $goProcesses = Get-Process -Name "go" -ErrorAction SilentlyContinue
-    if ($goProcesses) {
-        $goProcesses | ForEach-Object {
-            "Killing go.exe process (PID: $($_.Id))" | log
-            Stop-Process -Id $_.Id -Force -ErrorAction SilentlyContinue
-        }
-        "go.exe processes terminated" | log
-    } else {
-        "No go.exe processes found" | log
-    }
-} catch {
-    "Warning: Failed to kill go.exe: $_" | log
-}
-
 # Give processes time to terminate
 Start-Sleep -Seconds 2
 
 # ============================================================================
-# Step 4: Full cleanup - remove all Ollama data and build artifacts
+# Step 4: Full cleanup - remove Ollama data and (build-mode) dist artifacts
 # ============================================================================
 "Step 4: Performing full cleanup of Ollama data and build artifacts..." | log
 
@@ -159,29 +137,24 @@ if (Test-Path $ollamaModelsPath) {
     "Ollama data directory not found at $ollamaModelsPath" | log
 }
 
-# Clean only dist directory (keeps the repo, build artifacts, and Go can still `go run .`)
-# Note: We preserve the cmake `build` directory because `go run . serve` may depend on
-# native llama.cpp libraries compiled there
+# Remove the build-mode dist directory if present (preserves the repo, cmake
+# build, ollama.exe, and Go module cache so the next iteration can reuse them).
 if (Test-Path $ollamaDir) {
-    try {
-        Push-Location $ollamaDir
-        
-        # Remove dist directory if it exists (standalone binary output, not needed for go run)
-        $distDir = Join-Path $ollamaDir "dist"
-        if (Test-Path $distDir) {
+    $distDir = Join-Path $ollamaDir "dist"
+    if (Test-Path $distDir) {
+        try {
             $dirSize = (Get-ChildItem $distDir -Recurse -ErrorAction SilentlyContinue | Measure-Object -Property Length -Sum).Sum / 1MB
             "Removing dist directory: $distDir (size: ~$([math]::Round($dirSize, 2)) MB)" | log
             Remove-Item -Recurse -Force $distDir -ErrorAction Stop
             "dist directory removed successfully" | log
+        } catch {
+            " ERROR - Failed to clean dist directory: $_" | log
         }
-        
-        Pop-Location
-        "Ollama cleanup completed (repo, build artifacts, and Go modules preserved for next run)" | log
-    } catch {
-        " ERROR - Failed to clean Ollama artifacts: $_" | log
+    } else {
+        "No dist directory present (custom-zip prep or already cleaned)" | log
     }
 } else {
-    "Ollama source directory not found at $ollamaDir" | log
+    "Ollama directory not found at $ollamaDir" | log
 }
 
 # ============================================================================


### PR DESCRIPTION
## Summary

This PR overhauls the `ollama` (Windows) and `mac_ollama` (macOS) scenarios:

1. **Windows: new "custom" mode** — `use_custom_ollama=true` skips the entire
   Go + Visual Studio + CMake + LLVM-MinGW + clone + compile chain and just
   extracts a pre-built `ollama-windows-*.zip` you supply. Cuts prep from
   ~20+ minutes to seconds and removes the toolchain dependency for labs that
   want to measure a specific shipped build.
2. **Windows: handle different ollama layouts** — All four
   scripts now find the binary at either `ollama\ollama.exe` (source build)
   or `ollama\app\ollama.exe` (custom zip).
3. **macOS: build the binary in prep** — was using `go run main.go` in setup,
   which on the current ollama release drops into an interactive menu and
   hangs the scenario. Prep now does `go build -o ollama .` once; setup, run,
   and teardown invoke `./ollama` directly. Side benefit: no per-iteration
   recompile in run.
4. **macOS: better failure diagnostics** — server crashes during the
   30-second readiness loop are detected immediately (was: silent 30s wait).
   The background server writes to its own log so its output survives even if
   HOBL's RPC channel times out. `git clone` is idempotent so re-prep doesn't
   fail with "destination already exists".

## Why

- **Custom binary mode (Windows)**: building ollama from source pulls in a
  full VS install, LLVM-MinGW, CMake, Go, and a Git clone. For studies that
  measure a specific ollama release rather than a head build, this is wasted
  setup time and a large fragility surface. Labs can now drop the official
  release zip into a resources folder and skip all of it.
- **`app\` layout fix (Windows)**: silently broke when ollama changed its
  Windows release packaging. Scripts were looking for `ollama\ollama.exe`,
  finding nothing, and erroring out.
- **`go run` → `./ollama` (macOS)**: `go run main.go` with no args runs
  ollama's top-level command, which in recent versions opens an interactive
  prompt and never exits. Setup would hang until HOBL's RPC timeout (30 min
  default). Building a real binary in prep also avoids re-compiling on
  every loop iteration in the run script.
- **Diagnostics**: the previous macOS setup waited 30s blindly for the
  server, then exited with `ERROR - Server did not start within 30 seconds`
  and nothing else. Server logs went to `/dev/null`. When this failed in
  the lab, there was no signal what went wrong.

## What changed

### Windows scenario (`scenarios/windows/ollama/`)

| File | Change |
|---|---|
| `ollama.py` | New params: `use_custom_ollama` (bool), `custom_resources_path` (path to folder containing the zip). Uploads the resources folder to the DUT and threads the flags into the prep invocation. Kills `ollama.exe` in `kill()`. |
| `ollama_resources/ollama_prep.ps1` | Early-exits the toolchain install when `-useCustomOllama` is set; extracts the zip into `hobl_bin\ollama` and verifies `--version` runs. Handles three zip layouts: flat root, single nested folder, and `app\ollama.exe` (current). |
| `ollama_resources/ollama_setup.ps1` | Resolves `$ollamaExe` to either `ollama\ollama.exe` or `ollama\app\ollama.exe`. |
| `ollama_resources/ollama_run.ps1` | Same fallback. |
| `ollama_resources/ollama_teardown.ps1` | Same fallback. Removed the legacy `go run .` invocations and the `go.exe` process-kill block (no longer relevant in custom mode and unnecessary in source-build mode). Path corrected from `\ollama` to `\hobl_bin\ollama`. Cleanup now removes only `dist\` (preserves repo, cmake build artifacts, Go module cache between iterations). |

`prep_version` was **not** bumped on Windows — the changes are backward-compatible with existing prepped DUTs (source-build path still works the same way).

### macOS scenario (`scenarios/MacOS/mac_ollama/`)

| File | Change |
|---|---|
| `mac_ollama.py` | `prep_version` bumped 6 → 7 so existing DUTs re-prep and produce the `./ollama` binary. |
| `mac_ollama_resources/mac_ollama_prep.sh` | `go mod tidy` followed by `go build -o ollama .`; verifies the binary runs and reports its `--version`. Idempotent git clone (reuses an existing repo, errors clearly if a non-repo directory is in the way). Adds `git fetch --tags` before checkout so existing clones can resolve `v0.20.8-rc0`. |
| `mac_ollama_resources/mac_ollama_setup.sh` | Invokes `./ollama serve` and `./ollama pull` directly. Captures `$SERVER_PID` and polls `kill -0` inside the readiness loop — fails immediately if the server crashes during startup instead of waiting the full 30s. Server stdout/stderr redirected to `mac_ollama_server.log` (was `/dev/null`); pull output to `mac_ollama_pull.log`. |
| `mac_ollama_resources/mac_ollama_run.sh` | `./ollama run` instead of `go run . run` (no per-iter recompile). |
| `mac_ollama_resources/mac_ollama_teardown.sh` | Kills the built binary by absolute path; keeps the legacy `go run . serve` pkill as a fallback for DUTs still on the old layout. |

All four macOS scripts now use the same lightweight `log()` / `check()` convention as the rest of the macOS scenarios (foundrylocal, pytorch_inf, etc.).

## Backward compatibility

- **Windows**: source-build path unchanged. Existing prepped DUTs continue
  to work without re-prep. Custom mode is opt-in via the new params.
- **macOS**: `prep_version` bumped 6 → 7. Existing DUTs will re-prep on the
  next run (clone is now idempotent, so the existing `/Users/Shared/hobl_bin/ollama`
  checkout is reused — re-prep is essentially just `go mod tidy` + `go build`).

## Validation

- **Windows source build**: ran end-to-end on an ARM64 DUT — prep, setup,
  run, teardown all green; gemma3 inference metrics captured.
- **Windows custom mode**: ran with a release `ollama-windows-amd64.zip`
  on an x64 DUT — extraction handles the `app\ollama.exe` layout, server
  starts, model pulls, inference runs, teardown clean.
- **macOS**: pending validation on next sync — previous failure was setup
  hanging at the ollama interactive menu (now fixed by going through the
  built binary).

## Files changed

```
scenarios/macos/mac_ollama/mac_ollama.py
scenarios/macos/mac_ollama/mac_ollama_resources/mac_ollama_prep.sh
scenarios/macos/mac_ollama/mac_ollama_resources/mac_ollama_run.sh
scenarios/macos/mac_ollama/mac_ollama_resources/mac_ollama_setup.sh
scenarios/macos/mac_ollama/mac_ollama_resources/mac_ollama_teardown.sh
scenarios/windows/ollama/ollama.py
scenarios/windows/ollama/ollama_resources/ollama_prep.ps1
scenarios/windows/ollama/ollama_resources/ollama_run.ps1
scenarios/windows/ollama/ollama_resources/ollama_setup.ps1
scenarios/windows/ollama/ollama_resources/ollama_teardown.ps1
```
