### PR TITLE
Teams setup update & hobl prep plan updated

### DIFF
--- a/scenarios/windows/onedrive_prep.py
+++ b/scenarios/windows/onedrive_prep.py
@@ -578,7 +578,7 @@ class oneDrivePrep(core.app_scenario.Scenario):
         self._kill("WinAppDriver.exe")
 
         # Reboot for improved robustness
-        logging.info("Rebooting after Office installation.")
+        logging.info("Rebooting after Onedrive setup.")
         self._dut_reboot()
 
 

--- a/scenarios/windows/run_plans_if_preps_passed.py
+++ b/scenarios/windows/run_plans_if_preps_passed.py
@@ -1,0 +1,100 @@
+# Copyright (c) Microsoft. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+##
+# Check if rundown_abl_prep scenarios have all passed, and if so, launch rundown_abl plan
+##
+
+import core.app_scenario
+from core.parameters import Params
+# Import the module (not the Prep class) so unittest's test loader does not
+# discover Prep as a TestCase in this module and run it. We only want to use
+# Prep.get_prep_scenarios() as a helper.
+import scenarios.common.prep as prep_module
+import fnmatch
+import os
+import requests
+import logging
+import core.arguments
+from urllib.parse import (
+    urlparse,
+    urlunparse,
+    urlencode
+)
+
+class RunPlansIfPrepsPassed(core.app_scenario.Scenario):
+    module = __module__.split('.')[-1]
+
+    # Set default parameters
+    Params.setDefault(module, 'prep_list', "abl_active cs_floor lvp teams", desc="List of prep scenarios to check the status of", multiple=True)
+    Params.setDefault(module, 'plans_to_launch', "hobl.ps1 hobl_phm.ps1 hobl_etl.ps1", valOptions=["@\\testplans"], desc="List of plans to launch if preps have passed, in order", multiple=True)
+
+    # Get Parameters
+    prep_list = Params.get(module, 'prep_list').split()
+    plans_to_launch = Params.get(module, 'plans_to_launch').split()
+    dashboard_url = Params.get('global', 'dashboard_url')
+    dut_architecture = Params.get('global', 'dut_architecture')
+    study_type = Params.getOverride('global', 'study_type')
+
+    is_prep = True
+
+
+    def setUp(self):
+        # Don't call base setUp so that we don't interact with DUT
+        return
+
+
+    def runTest(self):
+        # Create an instance of the Prep scenario to use its get_prep_scenarios() function, 
+        # which will check the status of preps in the hierarchy under the specified scenarios 
+        # and return a list of any that still need to be run.
+        prep_instance = prep_module.Prep()
+        prep_instance.scenarios_to_prep = self.prep_list
+        scenarios_needing_prep = prep_instance.get_prep_scenarios()
+
+        
+        # If get_prep_scenarios() returns an empty list, all preps have been completed
+        if len(scenarios_needing_prep) == 0:
+            logging.info("All required preps have been completed. Proceeding to launch plans.")
+            args = core.arguments.args
+            params_file = args.profile
+            profile = os.path.basename(params_file).rsplit('.',1)[0]
+
+            url = urlunparse(
+                urlparse(self.dashboard_url)._replace(
+                    path="/plan/RunPlan"
+                )
+            )
+
+            study_type_param = ""
+
+            if self.study_type:
+                study_type_param = f"&studyType={self.study_type}"
+
+            for plan in self.plans_to_launch:
+                if plan == "hobl_phm.ps1" and self.dut_architecture.lower() != "x64":
+                    logging.info("Skipping hobl_phm.ps1 because dut_architecture is not x64")
+                    continue
+
+                response = requests.get(url + "?profile=" + profile + "&plan=" + plan + study_type_param)
+                logging.info("Launching " + plan + " for profile " + profile + ": " + str(response))
+        else:
+            # Preps still pending
+            prep_names = []
+            for p in scenarios_needing_prep:
+                if isinstance(p, tuple):
+                    prep_names.append(p[0])
+                else:
+                    prep_names.append(p)
+            logging.warning(f"The following preps are still pending: {', '.join(prep_names)}")
+            self._assert(f"Preps still pending: {', '.join(prep_names)}")
+
+
+    def tearDown(self):
+        # Don't call base tearDown so that we don't interact with DUT
+        return
+
+
+    def kill(self):
+        # Prevent base kill routine from running
+        return 0

--- a/scenarios/windows/teams_install.py
+++ b/scenarios/windows/teams_install.py
@@ -136,9 +136,9 @@ class TeamsInstall(core.app_scenario.Scenario):
         # Try to finish setup for built in teams.
         else:
             # First confirm the MSTeams Appx package is actually installed before
-            # we go poking at the taskbar / search bar. Without this check, typing
+            # checking the taskbar / search bar. Without this check, typing
             # "Microsoft Teams" into search on a device where Teams isn't installed
-            # would surface web suggestions and could launch Edge.
+            # could launch Edge search.
             teams_pkg = self._call(
                 ["powershell.exe", "(Get-AppxPackage -Name MSTeams).PackageFullName"],
                 expected_exit_code=""
@@ -162,6 +162,7 @@ class TeamsInstall(core.app_scenario.Scenario):
                     finish_setup_btn.click()
                     logging.info("Clicked 'Finish setup'.")
                     time.sleep(180)
+                    ActionChains(desktop).send_keys(Keys.ENTER).perform() # Incase canera permissions pop up need to dismiss it.
                 except:
                     logging.info("Teams not found in taskbar, trying to launch via start menu search.")
                     try:
@@ -178,6 +179,7 @@ class TeamsInstall(core.app_scenario.Scenario):
                         finish_setup_btn.click()
                         logging.info("Clicked 'Finish setup'.")
                         time.sleep(180)
+                        ActionChains(desktop).send_keys(Keys.ENTER).perform() # Incase canera permissions pop up need to dismiss it.
                     except:
                         try:
                             logging.debug("Killing msedge in case it was launched because teams isn't installed.")

--- a/testplans/hobl_prep.ps1
+++ b/testplans/hobl_prep.ps1
@@ -3,9 +3,10 @@ if ($ARGS[0] -eq $null) {return("Params .ini not supplied, please supply a param
 .\hobl.cmd -p $ARGS[0] -s net_prep attempts=2 connection=Wi-Fi post_run_delay=0
 .\hobl.cmd -p $ARGS[0] -s os_install post_run_delay=0
 
+.\hobl.cmd -p $ARGS[0] -s teams_install post_run_delay=0
 .\hobl.cmd -p $ARGS[0] -s prep post_run_delay=0 prep:scenarios_to_prep="abl_active cs_floor lvp teams"
 
 .\hobl.cmd -p $ARGS[0] -s net_prep attempts=2 post_run_delay=0
 .\hobl.cmd -p $ARGS[0] -s version_report post_run_delay=0
 .\hobl.cmd -p $ARGS[0] -s notify post_run_delay=0  
-.\hobl.cmd -p $ARGS[0] -s run_hobl_if_preps_passed post_run_delay=0
+.\hobl.cmd -p $ARGS[0] -s run_plans_if_preps_passed post_run_delay=0


### PR DESCRIPTION
- teams_install - updated so it will dismiss camera access permissions if teams pre-logins to DUT's MSA account. 
- hobl_prep.ps1 - updated plan to run teams_install and use new run_plans_if_preps_passed scenario that will run hobl plan if preps passed.
- run_plans_if_preps_passed.py - created new scenario that will take in preps and plans. The scenario will check the preps to see if they passed and if they did it will run the plans passed in.