### PR TITLE
Improve Ollama setup diagnostics and prevent silent setup timeouts

### DIFF
--- a/scenarios/windows/ollama/ollama.py
+++ b/scenarios/windows/ollama/ollama.py
@@ -14,7 +14,7 @@ from datetime import datetime
 class Ollama(core.app_scenario.Scenario):
 
     module = __module__.split('.')[-1]
-    prep_version = "6"
+    prep_version = "7"
     resources = module + "_resources"
 
 
@@ -73,7 +73,7 @@ class Ollama(core.app_scenario.Scenario):
         # Start server in background
         logging.info("Starting server")
         try:
-            self._call(["pwsh", f"{self.target}\\{self.module}_setup.ps1"])
+            self._call(["pwsh", f"{self.target}\\{self.module}_setup.ps1"], timeout=7200)
         finally:
             self._copy_data_from_remote(self.result_dir)
 

--- a/scenarios/windows/ollama/ollama_resources/ollama_setup.ps1
+++ b/scenarios/windows/ollama/ollama_resources/ollama_setup.ps1
@@ -1,26 +1,36 @@
 # Copyright (c) Microsoft. All rights reserved.
 # Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+# Initialize logging IMMEDIATELY (before anything else) so we catch all failures
+$scriptDrive = Split-Path -Qualifier $PSScriptRoot
+$logFile = "$scriptDrive\hobl_data\ollama_setup.log"
+$logDir = Split-Path $logFile -Parent
+
+# Create log directory and write first marker
+if (-not (Test-Path $logDir)) { 
+    New-Item -ItemType Directory -Path $logDir -Force | Out-Null 
+}
+Add-Content -Path $logFile -encoding utf8 "=== ollama_setup.ps1 execution started at $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss.fff') ==="
+Add-Content -Path $logFile -encoding utf8 "Script location: $PSCommandPath"
+Add-Content -Path $logFile -encoding utf8 "PowerShell version: $($PSVersionTable.PSVersion)"
+
 # Require PowerShell > 7
 $required = [version]"7.0"
 if (-not $PSVersionTable.PSVersion) {
+    Add-Content -Path $logFile -encoding utf8 " ERROR - Cannot determine PowerShell version; aborting."
     Write-Host "Cannot determine PowerShell version; aborting." -ForegroundColor Red
     Exit 1
 }
 if ([version]$PSVersionTable.PSVersion -le $required) {
+    Add-Content -Path $logFile -encoding utf8 " ERROR - PowerShell version $($PSVersionTable.PSVersion) is less than required $required"
     Write-Host "This script requires PowerShell greater than $required. Current: $($PSVersionTable.PSVersion)" -ForegroundColor Yellow
     Write-Host "Please install PowerShell 7 or later from https://aka.ms/powershell" -ForegroundColor Yellow
     Exit 1
 }
+Add-Content -Path $logFile -encoding utf8 "PowerShell version check passed."
+
 
 # [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
-
-$scriptDrive = Split-Path -Qualifier $PSScriptRoot
-$logFile = "$scriptDrive\hobl_data\ollama_setup.log"
-
-# Ensure log directory exists
-$logDir = Split-Path $logFile -Parent
-if (-not (Test-Path $logDir)) { New-Item -ItemType Directory -Path $logDir -Force | Out-Null }
 
 function log {
     [CmdletBinding()] Param([Parameter(ValueFromPipeline)] $msg)
@@ -53,10 +63,8 @@ function checkSetLocation {
     }
 }
 
-Set-Content -Path $logFile -encoding utf8 "-- ollama setup started"
-"-- ollama setup started" | log
-
 $Env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
+"-- ollama setup starting execution phase" | log
 
 checkSetLocation "$scriptDrive\hobl_bin\ollama"
 
@@ -150,7 +158,49 @@ if (-not $serverReady) {
 }
 
 "-- Pulling gemma3" | log
-& $ollamaExe pull gemma3
-check($lastexitcode)
+$pullStdOut = Join-Path $logDir "ollama_pull_stdout.log"
+$pullStdErr = Join-Path $logDir "ollama_pull_stderr.log"
+$pullTimeoutSec = 5400
+$pullHeartbeatSec = 30
+"-- Pull stdout redirected to: $pullStdOut" | log
+"-- Pull stderr redirected to: $pullStdErr" | log
+"-- Starting model pull with timeout: $pullTimeoutSec seconds" | log
+
+$pullProc = Start-Process -FilePath $ollamaExe `
+    -ArgumentList "pull", "gemma3" `
+    -WindowStyle Hidden `
+    -RedirectStandardOutput $pullStdOut `
+    -RedirectStandardError $pullStdErr `
+    -PassThru
+
+$elapsedSec = 0
+while (-not $pullProc.HasExited -and $elapsedSec -lt $pullTimeoutSec) {
+    Start-Sleep -Seconds 1
+    $elapsedSec++
+
+    if (($elapsedSec % $pullHeartbeatSec) -eq 0) {
+        "-- Pull in progress... elapsed=${elapsedSec}s pid=$($pullProc.Id)" | log
+    }
+}
+
+if (-not $pullProc.HasExited) {
+    " ERROR - Model pull timed out after $pullTimeoutSec seconds" | log
+    " ERROR - Terminating pull process (pid=$($pullProc.Id))" | log
+    Stop-Process -Id $pullProc.Id -Force -ErrorAction SilentlyContinue
+    Exit 1
+}
+
+if ($pullProc.ExitCode -ne 0) {
+    " ERROR - Model pull failed with exit code $($pullProc.ExitCode)" | log
+    " ERROR - See $pullStdOut and $pullStdErr for full details." | log
+
+    if (Test-Path $pullStdErr) {
+        Get-Content -Path $pullStdErr -Tail 20 -ErrorAction SilentlyContinue | ForEach-Object { "pull-stderr: $_" | log }
+    }
+
+    Exit $pullProc.ExitCode
+}
+
+"-- Model pull completed successfully in ${elapsedSec}s" | log
 
 Exit 0


### PR DESCRIPTION
## Summary
This PR improves reliability and diagnosability for the Windows Ollama scenario when setup can run for longer durations (especially during model pull).

It addresses cases where setup appeared to produce no logs in HOBL due to timeout behavior and non-streaming RPC output collection.

## Problem
On ARM64 DUT runs, Ollama setup could exceed the default RPC timeout during `ollama pull gemma3`.

Observed symptoms:
- Setup call timed out at the framework default window.
- Very limited/no useful setup output surfaced in `hobl.log`.
- Result triage was difficult because there was not enough persistent progress logging from the setup phase.

## Root Cause
- Setup used the default `_call(...)` timeout in `ollama.py` for setup, which was shorter than possible model-pull duration.
- Pull execution had no internal timeout/heartbeat.
- Long-running output depended on RPC return behavior; this path is completion-based rather than a live line-by-line stream.

## Changes
### 1) Increase setup RPC timeout in scenario runner
- File: `scenarios/windows/ollama/ollama.py`
- Change: setup call now uses explicit timeout:
  - from: `_call(["pwsh", "..._setup.ps1"])`
  - to: `_call(["pwsh", "..._setup.ps1"], timeout=7200)`

### 2) Add robust setup diagnostics and bounded pull behavior
- File: `scenarios/windows/ollama/ollama_resources/ollama_setup.ps1`
- Added immediate durable log initialization at script start.
- Added early PowerShell version logging/error lines persisted to file.
- Added explicit pull output files:
  - `ollama_pull_stdout.log`
  - `ollama_pull_stderr.log`
- Replaced direct pull call with managed process execution:
  - `Start-Process ... -PassThru`
  - heartbeat progress every 30 seconds
  - pull timeout guard (`$pullTimeoutSec = 5400`)
  - explicit timeout failure handling and process termination
  - tail of stderr on failure to improve triage
- Aligned error log formatting to existing script convention (`" ERROR - ..."`).

### 3) Bump prep version to force updated resource deployment
- File: `scenarios/windows/ollama/ollama.py`
- Change: `prep_version` incremented from `6` to `7`
- Reason: ensure DUTs re-run prep/upload path and consume updated scenario resources/scripts reliably.

## Validation
- Local script validation on DUT was completed.
- No syntax/errors reported in edited files after update.
- Expected artifacts for future failures/successes now include:
  - `ollama_setup.log`
  - `ollama_pull_stdout.log`
  - `ollama_pull_stderr.log`

## Impact
- Scope is limited to Windows Ollama scenario only.
- No changes to shared core RPC implementation.
- Improves diagnostics and reduces ambiguity for long-running setup/pull behavior.

## Risk and Mitigation
- Risk: Longer setup timeout can hold a run longer when network/model registry is unhealthy.
- Mitigation:
  - Internal pull timeout prevents unbounded hangs.
  - Heartbeat + split pull logs make failures actionable.