### PR TITLE
Fix/winget msstore source + REAME inclusion for SW Heavy Workloads

### DIFF
--- a/scenarios/windows/fast_api/README.md
+++ b/scenarios/windows/fast_api/README.md
@@ -1,0 +1,41 @@
+# FastAPI Build & Test Workload
+
+Python developer inner-loop benchmark. It builds the [FastAPI](https://github.com/fastapi/fastapi)
+library from source using a PEP 517 build (PDM backend), then runs the project's full test
+suite under `coverage`. It measures **build time** and **test time** separately and reports
+their sum as the scenario runtime — a proxy for Python package build + test performance.
+
+## What HOBL sets up (from `fast_api_resources/fast_api_prep.ps1`)
+
+- Python 3.12.10 via pyenv (isolated venv)
+- Visual Studio 2022 C++ build tools (for native extension builds)
+- Git (winget)
+- Clones `https://github.com/fastapi/fastapi.git` to `<drive>\fastapi`
+
+## Run it standalone (Windows)
+
+```powershell
+# 1. Prerequisites
+winget install --id Git.Git --source winget
+pyenv install 3.12.10; pyenv local 3.12.10
+
+# 2. Clone the repo
+git clone https://github.com/fastapi/fastapi.git
+cd fastapi
+
+# 3. Isolated venv + build/test tooling
+python -m venv .venv
+.\.venv\Scripts\Activate.ps1
+python -m pip install build coverage pytest
+python -m pip install -r requirements-tests.txt
+
+# 4. Timed workload
+python -m build                        # PEP 517 build -> dist/
+python -m coverage run -m pytest tests
+```
+
+## Notes
+
+- The PEP 517 build spins up its own isolated environment. On a proxied corporate network,
+  set `$env:PIP_INDEX_URL` to your approved PyPI mirror so build isolation can fetch deps.
+- HOBL default: 5 loops (each loop = build + test). Works on x64 and ARM64.

--- a/scenarios/windows/fast_api/fast_api_resources/fast_api_prep.ps1
+++ b/scenarios/windows/fast_api/fast_api_resources/fast_api_prep.ps1
@@ -441,8 +441,20 @@ Set-Content -Path $logFile -encoding utf8 "-- FastAPI prep started ($logSuffix v
 "Using Visual Studio $vsProduct for $logSuffix" | log
 
 
+# --- Remove the msstore source before any winget install so a broken pinned
+# certificate on that source cannot fail the command (winget 0x8a15005e /
+# -1978335138) behind an SSL-inspecting proxy. All needed packages are on 'winget'. ---
+try {
+    if ((winget source list 2>$null) -match "msstore") {
+        "Removing msstore winget source to avoid pinned-certificate failures (0x8a15005e)" | log
+        winget source remove msstore 2>&1 | log
+    }
+} catch {
+    "Could not remove msstore source (continuing): $($_.Exception.Message)" | log
+}
+
 "-- Installing git" | log
-winget install --id git.git --accept-source-agreements --accept-package-agreements
+winget install --id git.git --source winget --accept-source-agreements --accept-package-agreements
 checkWinget($lastexitcode)
 $Env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
 

--- a/scenarios/windows/foundrylocal/README.md
+++ b/scenarios/windows/foundrylocal/README.md
@@ -1,0 +1,38 @@
+# Foundry Local Inference Workload
+
+Edge LLM inference benchmark built on
+[Microsoft Foundry Local](https://learn.microsoft.com/azure/ai-foundry/foundry-local/).
+It starts the Foundry Local service, ensures a model is cached (default
+`Phi-3.5-mini-instruct-generic-cpu`), runs a single-prompt inference, and reports the
+end-to-end runtime.
+
+## What HOBL sets up (from `foundrylocal_resources/*.ps1`)
+
+- `Microsoft.FoundryLocal` (winget)
+- Model downloaded on demand via `foundry model download` (several GB, cached locally)
+
+## Run it standalone (Windows)
+
+```powershell
+winget install --id Microsoft.FoundryLocal --source winget
+
+# Refresh PATH so `foundry` resolves in this session
+$env:Path = [Environment]::GetEnvironmentVariable("Path","Machine") + ";" + `
+            [Environment]::GetEnvironmentVariable("Path","User")
+
+foundry service start
+foundry model download "Phi-3.5-mini-instruct-generic-cpu"
+foundry cache list
+
+# Timed workload
+foundry model run "Phi-3.5-mini-instruct-generic-cpu" --prompt "What is the meaning of life?"
+
+# Cleanup (avoids disk bloat — models are not auto-expired)
+foundry cache remove "Phi-3.5-mini-instruct-generic-cpu" --yes
+foundry service stop
+```
+
+## Notes
+
+- Default: 1 loop. Works on x64 and ARM64.
+- First run downloads the model; the HOBL teardown removes it afterward.

--- a/scenarios/windows/foundrylocal/foundrylocal_resources/foundrylocal_prep.ps1
+++ b/scenarios/windows/foundrylocal/foundrylocal_resources/foundrylocal_prep.ps1
@@ -98,8 +98,20 @@ Set-Content -Path $logFile -encoding utf8 "-- Foundry Local prep started ($logSu
 # ============================================================================
 "Step 1: Installing AI Foundry Local..." | log
 
+# --- Remove the msstore source before any winget install so a broken pinned
+# certificate on that source cannot fail the command (winget 0x8a15005e /
+# -1978335138) behind an SSL-inspecting proxy. All needed packages are on 'winget'. ---
+try {
+    if ((winget source list 2>$null) -match "msstore") {
+        "Removing msstore winget source to avoid pinned-certificate failures (0x8a15005e)" | log
+        winget source remove msstore 2>&1 | log
+    }
+} catch {
+    "Could not remove msstore source (continuing): $($_.Exception.Message)" | log
+}
+
 "Installing Microsoft.FoundryLocal version $foundryVersion via winget..." | log
-winget install Microsoft.FoundryLocal --version $foundryVersion --accept-source-agreements --accept-package-agreements 2>&1 | ForEach-Object { "  $_" | log }
+winget install Microsoft.FoundryLocal --source winget --version $foundryVersion --accept-source-agreements --accept-package-agreements 2>&1 | ForEach-Object { "  $_" | log }
 checkWinget $LASTEXITCODE
 
 # Refresh PATH to pick up newly installed foundry

--- a/scenarios/windows/llvm/README.md
+++ b/scenarios/windows/llvm/README.md
@@ -1,0 +1,39 @@
+# LLVM Build Workload
+
+Compiler-infrastructure build benchmark. It clones the
+[LLVM project](https://github.com/llvm/llvm-project) at tag `llvmorg-21.1.8`, configures a
+Ninja + CMake build, and performs a full from-clean build. It reports total build time — a
+heavy, real-world CPU / memory / I/O compile workload.
+
+## What HOBL sets up (from `llvm_resources/llvm_prep.ps1`)
+
+- Python 3.12.10 (pyenv) and Visual Studio 2022 C++ build tools
+- winget: Git, Ninja, CMake
+- A pre-built LLVM 21.1.8 toolchain (installer → `C:\Program Files\llvm`)
+- Clones `llvm/llvm-project` @ `llvmorg-21.1.8` to `<drive>\llvm-project`; build dir `<drive>\build_llvm`
+
+## Run it standalone (Windows)
+
+```powershell
+winget install --id Git.Git --source winget
+winget install --id Ninja-build.Ninja --source winget
+winget install --id Kitware.CMake --source winget
+# + Visual Studio 2022 with the "Desktop development with C++" workload
+
+git clone --depth 1 --branch llvmorg-21.1.8 --config core.autocrlf=false `
+  https://github.com/llvm/llvm-project.git
+
+# From a Developer PowerShell (VsDevCmd loaded for your arch, e.g. -arch=x64 or -arch=arm64):
+cmake -G Ninja -S llvm-project\llvm -B build_llvm -DCMAKE_BUILD_TYPE=Release `
+  -DLLVM_ENABLE_PROJECTS="clang;lld"
+
+# Timed workload
+ninja -C build_llvm
+```
+
+## Notes
+
+- The CMake configure line above is representative — see `llvm_resources/llvm_prep.ps1`
+  for the exact project/runtime targets and flags HOBL uses.
+- Load the MSVC environment first (`VsDevCmd.bat -arch=x64` or `-arch=arm64`).
+- Expect a long build (tens of minutes or more). Default: 1 loop. Works on x64 and ARM64.

--- a/scenarios/windows/llvm/llvm_resources/llvm_prep.ps1
+++ b/scenarios/windows/llvm/llvm_resources/llvm_prep.ps1
@@ -283,30 +283,42 @@ Set-Content -Path $logFile -encoding utf8 "-- llvm prep started ($logSuffix vers
 # Refresh PATH
 $Env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
 
+# --- Remove the msstore source before any winget install so a broken pinned
+# certificate on that source cannot fail the command (winget 0x8a15005e /
+# -1978335138) behind an SSL-inspecting proxy. All needed packages are on 'winget'. ---
+try {
+    if ((winget source list 2>$null) -match "msstore") {
+        "Removing msstore winget source to avoid pinned-certificate failures (0x8a15005e)" | log
+        winget source remove msstore 2>&1 | log
+    }
+} catch {
+    "Could not remove msstore source (continuing): $($_.Exception.Message)" | log
+}
+
 # --- Install VC Runtime Redistributable ---
 "-- Installing VC Runtime Redistributable" | log
 if ($isARM64) {
-    winget install --id=Microsoft.VCRedist.2015+.arm64 --silent --accept-package-agreements --accept-source-agreements --scope=machine
+    winget install --id=Microsoft.VCRedist.2015+.arm64 --source winget --silent --accept-package-agreements --accept-source-agreements --scope=machine
 } else {
-    winget install --id=Microsoft.VCRedist.2015+.x64 --silent --accept-package-agreements --accept-source-agreements --scope=machine
+    winget install --id=Microsoft.VCRedist.2015+.x64 --source winget --silent --accept-package-agreements --accept-source-agreements --scope=machine
 }
 checkWinget($lastexitcode)
 
 # --- Install Git ---
 "-- Installing Git" | log
-winget install --id Git.Git --silent --accept-source-agreements --accept-package-agreements
+winget install --id Git.Git --source winget --silent --accept-source-agreements --accept-package-agreements
 checkWinget($lastexitcode)
 $Env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
 
 # --- Install CMake ---
 "-- Installing CMake" | log
-winget install --id Kitware.CMake --version 4.1.1 --silent --accept-source-agreements --accept-package-agreements
+winget install --id Kitware.CMake --version 4.1.1 --source winget --silent --accept-source-agreements --accept-package-agreements
 checkWinget($lastexitcode)
 $Env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
 
 # --- Install Ninja ---
 "-- Installing Ninja" | log
-winget install --id Ninja-build.Ninja --version 1.13.2 --silent --accept-source-agreements --accept-package-agreements
+winget install --id Ninja-build.Ninja --version 1.13.2 --source winget --silent --accept-source-agreements --accept-package-agreements
 checkWinget($lastexitcode)
 $Env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
 

--- a/scenarios/windows/mlperf/README.md
+++ b/scenarios/windows/mlperf/README.md
@@ -1,0 +1,39 @@
+# MLPerf Client Workload
+
+Runs the [MLPerf Client](https://github.com/mlcommons/mlperf_client) v1.5 LLM benchmark
+offline. On Snapdragon X-class ARM64 devices it executes Phi-3.5 inference across several
+task categories using Windows ML with the Qualcomm QNN NPU execution provider, and reports
+the benchmark duration.
+
+## What HOBL sets up (from `mlperf_resources/mlperf_prep.ps1`)
+
+- `Microsoft.WindowsAppRuntime.1.8` (winget)
+- MLPerf Client v1.5 zip (GitHub release) → `<drive>\hobl_bin\mlperf`
+- (ARM64) WinML QNN execution-provider MSIX via `Add-AppxPackage`
+
+## Run it standalone (Windows, ARM64 / Snapdragon)
+
+```powershell
+winget install --id Microsoft.WindowsAppRuntime.1.8 --source winget
+
+# Download + extract the client (ARM64 example)
+Invoke-WebRequest "https://github.com/mlcommons/mlperf_client/releases/download/v1.5/mlperf-client-1.5.0-8665cb1-windows-arm64.zip" -OutFile mlperf.zip
+Expand-Archive mlperf.zip -DestinationPath C:\hobl_bin\mlperf
+
+# (Snapdragon) install the QNN execution provider
+Add-AppxPackage -Path C:\hobl_bin\mlperf\qnnep_arm.msix
+
+# Timed workload
+C:\hobl_bin\mlperf\mlperf-windows.exe `
+  --config "C:\hobl_bin\mlperf\Config_Phi3.5_WindowsML_QNN_NPU.json" `
+  --output-dir "C:\hobl_data" --download_behaviour skip_all --pause false
+```
+
+## Notes
+
+- See `mlperf_resources/mlperf_prep.ps1` and `mlperf_run.ps1` for the exact release URL and
+  config filename used.
+- The default config targets the Qualcomm NPU (ARM64); x64 binaries exist but the default
+  config is Snapdragon-specific.
+- Results land in `results.json` ("Benchmark Duration"). Admin is required for the MSIX install.
+- Default: 1 loop.

--- a/scenarios/windows/mlperf/mlperf_resources/mlperf_prep.ps1
+++ b/scenarios/windows/mlperf/mlperf_resources/mlperf_prep.ps1
@@ -101,8 +101,20 @@ Set-Content -Path $logFile -encoding utf8 "-- MLPerf prep started ($logSuffix ve
 # -------------------------------------------------------------------
 # Install Windows App SDK, required for MLPerf client
 # -------------------------------------------------------------------
+# --- Remove the msstore source before any winget install so a broken pinned
+# certificate on that source cannot fail the command (winget 0x8a15005e /
+# -1978335138) behind an SSL-inspecting proxy. All needed packages are on 'winget'. ---
+try {
+    if ((winget source list 2>$null) -match "msstore") {
+        "Removing msstore winget source to avoid pinned-certificate failures (0x8a15005e)" | log
+        winget source remove msstore 2>&1 | log
+    }
+} catch {
+    "Could not remove msstore source (continuing): $($_.Exception.Message)" | log
+}
+
 "-- Installing Windows App SDK" | log
-winget install --id Microsoft.WindowsAppRuntime.1.8 --accept-source-agreements --accept-package-agreements
+winget install --id Microsoft.WindowsAppRuntime.1.8 --source winget --accept-source-agreements --accept-package-agreements
 checkWinget($lastexitcode)
 
 # Create mlperf directory if it doesn't exist

--- a/scenarios/windows/net_aspire/README.md
+++ b/scenarios/windows/net_aspire/README.md
@@ -1,0 +1,34 @@
+# .NET Aspire Build Workload
+
+Builds the [.NET Aspire](https://github.com/dotnet/aspire) cloud-app orchestration stack from
+source (tag `v9.4.2`). It restores, cleans, then performs a no-restore rebuild of
+`Aspire.slnx` and reports build time — a large managed (.NET / MSBuild) build workload.
+
+## What HOBL sets up (from `net_aspire_resources/net_aspire_prep.ps1`)
+
+- winget: .NET SDK 10 preview, .NET SDK 8, Git
+- Clones `dotnet/aspire` @ `v9.4.2` to `<drive>\aspire`
+
+## Run it standalone (Windows)
+
+```powershell
+winget install --id Microsoft.DotNet.SDK.Preview --source winget --version 10.0.100-preview.5.25277.114
+winget install --id Microsoft.DotNet.SDK.8 --source winget
+winget install --id Git.Git --source winget
+
+git clone https://github.com/dotnet/aspire.git
+cd aspire
+git checkout v9.4.2
+
+# Timed workload
+dotnet restore Aspire.slnx
+dotnet clean Aspire.slnx
+dotnet build Aspire.slnx --no-restore
+```
+
+## Notes
+
+- On ARM64, HOBL points `DOTNET_INSTALL_DIR` at the system dotnet to avoid pulling an
+  x64-only legacy runtime. If `dotnet restore` complains about an old runtime, set
+  `$env:DOTNET_INSTALL_DIR="C:\Program Files\dotnet"`.
+- Aspire restores only from Microsoft/dnceng NuGet feeds. Default: 4 loops.

--- a/scenarios/windows/net_aspire/net_aspire_resources/net_aspire_prep.ps1
+++ b/scenarios/windows/net_aspire/net_aspire_resources/net_aspire_prep.ps1
@@ -116,8 +116,20 @@ Set-Content -Path $logFile -encoding utf8 "-- net_aspire prep started ($logSuffi
 # -------------------------------------------------------------------
 # Install .NET SDK
 # -------------------------------------------------------------------
+# --- Remove the msstore source before any winget install so a broken pinned
+# certificate on that source cannot fail the command (winget 0x8a15005e /
+# -1978335138) behind an SSL-inspecting proxy. All needed packages are on 'winget'. ---
+try {
+    if ((winget source list 2>$null) -match "msstore") {
+        "Removing msstore winget source to avoid pinned-certificate failures (0x8a15005e)" | log
+        winget source remove msstore 2>&1 | log
+    }
+} catch {
+    "Could not remove msstore source (continuing): $($_.Exception.Message)" | log
+}
+
 "-- Installing .NET SDK 10.0 - 10.0.100-preview.5.25277.114 same version that's in restore.cmd" | log
-winget install --id Microsoft.DotNet.SDK.Preview --version 10.0.100-preview.5.25277.114 --accept-source-agreements --accept-package-agreements
+winget install --id Microsoft.DotNet.SDK.Preview --source winget --version 10.0.100-preview.5.25277.114 --accept-source-agreements --accept-package-agreements
 checkWinget($lastexitcode)
 $Env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
 
@@ -125,7 +137,7 @@ $Env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";
 # Install .NET 8.0 SDK
 # -------------------------------------------------------------------
 "-- Installing .NET 8.0 SDK" | log
-winget install --id Microsoft.DotNet.SDK.8 --accept-source-agreements --accept-package-agreements
+winget install --id Microsoft.DotNet.SDK.8 --source winget --accept-source-agreements --accept-package-agreements
 checkWinget($lastexitcode)
 $Env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
 
@@ -157,7 +169,7 @@ if ($isARM64) {
 # Install Git
 # -------------------------------------------------------------------
 "-- Installing git" | log
-winget install --id Git.Git --accept-source-agreements --accept-package-agreements
+winget install --id Git.Git --source winget --accept-source-agreements --accept-package-agreements
 checkWinget($lastexitcode)
 $Env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
 

--- a/scenarios/windows/nodejs/README.md
+++ b/scenarios/windows/nodejs/README.md
@@ -1,0 +1,32 @@
+# Node.js Build Workload
+
+Builds [Node.js](https://github.com/nodejs/node) v25.0.0 from source with the MSVC native
+build system (`vcbuild.bat`), compiling the runtime and OpenSSL with `openssl-no-asm` for
+cross-architecture reproducibility. It reports total build time — a heavy C++ build benchmark.
+
+## What HOBL sets up (from `nodejs_resources/nodejs_prep.ps1`)
+
+- Visual Studio 2022 C++ build tools, Git, Python 3.12.10 (pyenv, required by `vcbuild.bat`)
+- Downloads the `nodejs/node` v25.0.0 source zip and extracts it to
+  `<drive>\hobl_bin\nodejs\node-25.0.0`
+
+## Run it standalone (Windows)
+
+```powershell
+# + Visual Studio 2022 with "Desktop development with C++"
+pyenv install 3.12.10; pyenv local 3.12.10
+
+Invoke-WebRequest "https://github.com/nodejs/node/archive/refs/tags/v25.0.0.zip" -OutFile node.zip
+Expand-Archive node.zip -DestinationPath .
+cd node-25.0.0
+
+# Timed workload (from a Developer prompt with VsDevCmd loaded)
+.\vcbuild.bat clean x64 openssl-no-asm       # arm64 on ARM64 devices
+.\vcbuild.bat release x64 openssl-no-asm
+```
+
+## Notes
+
+- Requires PowerShell 7+. Expect a long build (tens of minutes).
+- Set `PYTHON` / `PYTHONHOME` to your pyenv Python so `vcbuild.bat` finds it.
+- HOBL teardown removes `out/`, `Release/`, and `Debug/` (frees ~2–3 GB). Default: 1 loop.

--- a/scenarios/windows/ollama/README.md
+++ b/scenarios/windows/ollama/README.md
@@ -1,0 +1,39 @@
+# Ollama Inference Workload
+
+Builds [Ollama](https://github.com/ollama/ollama) from source (tag `v0.20.8-rc0`), starts the
+server, pulls a model (default `gemma3`), and runs a prompt in verbose mode. It reports
+inference metrics: total duration, time-to-first-token (TTFT), and tokens/second.
+
+## What HOBL sets up (from `ollama_resources/*.ps1`)
+
+- winget: Visual Studio 2022, Go 1.25.1, Git, CMake 4.1.1
+- LLVM-MinGW toolchain (GitHub release → `C:\Program Files`)
+- Clones `ollama/ollama` @ `v0.20.8-rc0` to `<drive>\hobl_bin\ollama`
+- Also supports a pre-built custom-binary path (skips all compilation)
+
+## Run it standalone (Windows)
+
+```powershell
+winget install --id GoLang.Go --source winget --version 1.25.1
+winget install --id git.git --source winget
+winget install --id KitWare.CMake --source winget
+# + Visual Studio 2022 C++ tools; download LLVM-MinGW and add its \bin to PATH
+
+git clone https://github.com/ollama/ollama.git
+cd ollama
+git checkout v0.20.8-rc0
+
+# Build (x64 builds GPU runners via cmake first; ARM64 is CPU-only)
+cmake -B build; cmake --build build      # x64 only
+go build -o ollama.exe .
+
+# Run
+.\ollama.exe serve                       # background; listens on http://localhost:11434
+.\ollama.exe pull gemma3
+.\ollama.exe run gemma3 "what is the meaning of life?" --verbose
+```
+
+## Notes
+
+- Requires PowerShell 7+. The server listens on `http://localhost:11434`.
+- Default: 1 loop. HOBL teardown removes the pulled model.

--- a/scenarios/windows/ollama/ollama_resources/ollama_prep.ps1
+++ b/scenarios/windows/ollama/ollama_resources/ollama_prep.ps1
@@ -534,12 +534,24 @@ if ($useCustomOllama) {
 # ============================================================================
 "Using Visual Studio $vsProduct for $logSuffix" | log
 
+# --- Remove the msstore source before any winget install so a broken pinned
+# certificate on that source cannot fail the command (winget 0x8a15005e /
+# -1978335138) behind an SSL-inspecting proxy. All needed packages are on 'winget'. ---
+try {
+    if ((winget source list 2>$null) -match "msstore") {
+        "Removing msstore winget source to avoid pinned-certificate failures (0x8a15005e)" | log
+        winget source remove msstore 2>&1 | log
+    }
+} catch {
+    "Could not remove msstore source (continuing): $($_.Exception.Message)" | log
+}
+
 "-- Installing GoLang 1.25.1" | log
-winget install --id GoLang.Go --version 1.25.1 --accept-source-agreements --accept-package-agreements
+winget install --id GoLang.Go --source winget --version 1.25.1 --accept-source-agreements --accept-package-agreements
 checkWinget($lastexitcode)
 
 "-- Installing git" | log
-winget install --id git.git --accept-source-agreements --accept-package-agreements
+winget install --id git.git --source winget --accept-source-agreements --accept-package-agreements
 checkWinget($lastexitcode)
 $Env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
 
@@ -591,7 +603,7 @@ if (-not (initializeVSEnvironment)) {
 $Env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
 
 "-- Installing CMake 4.1.1" | log
-winget install --id KitWare.CMake --version 4.1.1 --accept-source-agreements --accept-package-agreements
+winget install --id KitWare.CMake --version 4.1.1 --source winget --accept-source-agreements --accept-package-agreements
 checkWinget($lastexitcode)
 
 "Refreshing environment variables after cmake installation..." | log

--- a/scenarios/windows/opencv_build/README.md
+++ b/scenarios/windows/opencv_build/README.md
@@ -1,0 +1,36 @@
+# OpenCV Build Workload
+
+Builds [OpenCV](https://github.com/opencv/opencv) (tag `4.10.0`) from source with MSVC + CMake
+as a monolithic "world" library in Release configuration. It reports compile time — a C++
+build benchmark.
+
+## What HOBL sets up (from `opencv_build_resources/opencv_build_prep.ps1`)
+
+- winget: Visual Studio 2022, Git, CMake 4.1.1
+- Clones `opencv/opencv` @ `4.10.0` to `<drive>\opencv`; build dir `<drive>\opencv\build_msvc`
+
+## Run it standalone (Windows)
+
+```powershell
+winget install --id git.git --source winget
+winget install --id KitWare.CMake --source winget
+# + Visual Studio 2022 with "Desktop development with C++"
+
+git clone https://github.com/opencv/opencv.git
+cd opencv
+git checkout tags/4.10.0
+mkdir build_msvc; cd build_msvc
+
+cmake -S .. -B . -G "Visual Studio 17 2022" -DBUILD_opencv_world=ON `
+  -DBUILD_TESTS=OFF -DBUILD_PERF_TESTS=OFF -DWITH_PYTHON=OFF
+
+# Timed workload
+cmake --build . --config Release
+cmake --build . --target INSTALL --config Release
+```
+
+## Notes
+
+- The CMake flags above are representative — see
+  `opencv_build_resources/opencv_build_prep.ps1` for the exact configuration HOBL uses.
+- Default: 1 loop. Works on x64 and ARM64.

--- a/scenarios/windows/opencv_build/opencv_build_resources/opencv_build_prep.ps1
+++ b/scenarios/windows/opencv_build/opencv_build_resources/opencv_build_prep.ps1
@@ -431,8 +431,20 @@ Set-Content -Path $logFile -encoding utf8 "-- opencv prep started ($logSuffix ve
 "Detected architecture: $arch (Processor: $processorArch)" | log
 "Using Visual Studio $vsProduct for $logSuffix" | log
 
+# --- Remove the msstore source before any winget install so a broken pinned
+# certificate on that source cannot fail the command (winget 0x8a15005e /
+# -1978335138) behind an SSL-inspecting proxy. All needed packages are on 'winget'. ---
+try {
+    if ((winget source list 2>$null) -match "msstore") {
+        "Removing msstore winget source to avoid pinned-certificate failures (0x8a15005e)" | log
+        winget source remove msstore 2>&1 | log
+    }
+} catch {
+    "Could not remove msstore source (continuing): $($_.Exception.Message)" | log
+}
+
 "-- Installing git" | log
-winget install --id git.git --accept-source-agreements --accept-package-agreements
+winget install --id git.git --source winget --accept-source-agreements --accept-package-agreements
 checkWinget($lastexitcode)
 $Env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
 
@@ -520,7 +532,7 @@ try {
 $Env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
 
 "-- Installing CMake 4.1.1" | log
-winget install --id KitWare.CMake --version 4.1.1 --accept-source-agreements --accept-package-agreements
+winget install --id KitWare.CMake --version 4.1.1 --source winget --accept-source-agreements --accept-package-agreements
 checkWinget($lastexitcode)
 
 "Refreshing environment variables after cmake installation..." | log

--- a/scenarios/windows/pytorch_inf/README.md
+++ b/scenarios/windows/pytorch_inf/README.md
@@ -1,0 +1,32 @@
+# PyTorch Inference Workload
+
+Runs text-generation inference with [PyTorch](https://pytorch.org/) + Hugging Face
+Transformers on `microsoft/Phi-4-mini-instruct`. It generates a response to a prompt and
+reports tokens/second, time-to-first-token (TTFT), and total generation time. GPU (CUDA 12.8)
+on x64; CPU-only on ARM64.
+
+## What HOBL sets up (from `pytorch_inf_resources/pytorch_inf_prep.ps1`)
+
+- Python (3.12.10 on x64 / 3.13.1-arm on ARM64) via pyenv, in a private venv
+- `torch` 2.8.0 (+CUDA 12.8 on x64), `transformers` 4.56.1, `tokenizers`, `safetensors`
+  (ARM64 compiles safetensors from source → requires Rust)
+- `inference.py` (bundled in `pytorch_inf_resources`)
+
+## Run it standalone (Windows)
+
+```powershell
+pyenv install 3.12.10; pyenv local 3.12.10        # 3.13.1-arm on ARM64
+python -m venv .venv; .\.venv\Scripts\Activate.ps1
+python -m pip install torch==2.8.0 transformers==4.56.1 tokenizers==0.22.2
+# ARM64: add  --index-url https://download.pytorch.org/whl/cpu
+#        and install Rust (winget Rustlang.Rustup) so safetensors can compile
+
+# Timed workload (run from pytorch_inf_resources/, where inference.py lives)
+python inference.py --prompt "What is the meaning of life?" --log-dir .
+```
+
+## Notes
+
+- `--no-gpu` forces CPU inference on x64. Metrics are written to a CSV in the log dir.
+- The model (Phi-4-mini) downloads from Hugging Face on first run.
+- Default: 2 loops.

--- a/scenarios/windows/pytorch_inf/pytorch_inf_resources/pytorch_inf_prep.ps1
+++ b/scenarios/windows/pytorch_inf/pytorch_inf_resources/pytorch_inf_prep.ps1
@@ -137,8 +137,20 @@ if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
 # Rust has no LTS — we pin a known stable version for reproducibility.
 $rustVersion = "1.85.0"
 if ($isARM64) {
+    # --- Remove the msstore source before any winget install so a broken pinned
+    # certificate on that source cannot fail the command (winget 0x8a15005e /
+    # -1978335138) behind an SSL-inspecting proxy. All needed packages are on 'winget'. ---
+    try {
+        if ((winget source list 2>$null) -match "msstore") {
+            "Removing msstore winget source to avoid pinned-certificate failures (0x8a15005e)" | log
+            winget source remove msstore 2>&1 | log
+        }
+    } catch {
+        "Could not remove msstore source (continuing): $($_.Exception.Message)" | log
+    }
+
     "-- Installing Rust toolchain $rustVersion (required for Arm64 native package compilation)" | log
-    winget install --id Rustlang.Rustup --accept-source-agreements --accept-package-agreements
+    winget install --id Rustlang.Rustup --source winget --accept-source-agreements --accept-package-agreements
     if ($LASTEXITCODE -ne 0 -and $LASTEXITCODE -ne -1978335189) {
         " ERROR - Rust installation failed with exit code: $LASTEXITCODE" | log
     } else {

--- a/scenarios/windows/spring_petclinic/README.md
+++ b/scenarios/windows/spring_petclinic/README.md
@@ -1,0 +1,38 @@
+# Spring PetClinic Build & Test Workload
+
+Builds and tests the [Spring PetClinic](https://github.com/spring-projects/spring-petclinic)
+Spring Boot sample app with Maven (`mvnw`), pinned to commit `6feeae0f…` for reproducibility.
+It runs an offline `package` then `test` and reports build time and test time — a Java /
+Maven developer inner-loop benchmark.
+
+## What HOBL sets up (from `spring_petclinic_resources/spring_petclinic_prep.ps1`)
+
+- winget: Microsoft OpenJDK 25, Git
+- Clones `spring-projects/spring-petclinic` @ commit
+  `6feeae0f13e0e258eedc99832416b42bb13779b1` to `<drive>\spring-petclinic`
+- Pre-populates a local Maven cache so builds run fully offline
+
+## Run it standalone (Windows)
+
+```powershell
+winget install --id Microsoft.OpenJDK.25 --source winget
+winget install --id git.git --source winget
+
+git clone https://github.com/spring-projects/spring-petclinic.git
+cd spring-petclinic
+git checkout 6feeae0f13e0e258eedc99832416b42bb13779b1
+
+# Populate the Maven cache once (online)
+.\mvnw.cmd -Dmaven.repo.local=..\m2-cache dependency:go-offline
+.\mvnw.cmd -Dmaven.repo.local=..\m2-cache verify
+
+# Timed workload (offline against the cache)
+.\mvnw.cmd clean
+.\mvnw.cmd -Dmaven.repo.local=..\m2-cache -DskipTests package -o
+.\mvnw.cmd -Dmaven.repo.local=..\m2-cache test -o
+```
+
+## Notes
+
+- The `package`/`test` phases run offline (`-o`) against the pre-populated cache.
+- Default: 5 loops (build + test each loop). Works on x64 and ARM64.

--- a/scenarios/windows/spring_petclinic/spring_petclinic_resources/spring_petclinic_prep.ps1
+++ b/scenarios/windows/spring_petclinic/spring_petclinic_resources/spring_petclinic_prep.ps1
@@ -48,11 +48,23 @@ function checkCmd {
 
 Set-Content -Path $logFile -encoding utf8 "-- spring_petclinic prep started"
 
+# --- Remove the msstore source before any winget install so a broken pinned
+# certificate on that source cannot fail the command (winget 0x8a15005e /
+# -1978335138) behind an SSL-inspecting proxy. All needed packages are on 'winget'. ---
+try {
+    if ((winget source list 2>$null) -match "msstore") {
+        "Removing msstore winget source to avoid pinned-certificate failures (0x8a15005e)" | log
+        winget source remove msstore 2>&1 | log
+    }
+} catch {
+    "Could not remove msstore source (continuing): $($_.Exception.Message)" | log
+}
+
 "-- Installing OpenJDK 25" | log
-winget install --id Microsoft.OpenJDK.25 --version 25.0.0.36 --accept-source-agreements --accept-package-agreements
+winget install --id Microsoft.OpenJDK.25 --source winget --version 25.0.0.36 --accept-source-agreements --accept-package-agreements
 
 "-- Installing git" | log
-winget install --id git.git --accept-source-agreements --accept-package-agreements
+winget install --id git.git --source winget --accept-source-agreements --accept-package-agreements
 $Env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
 
 "-- Setting up Java 25 environment" | log

--- a/scenarios/windows/vscode/README.md
+++ b/scenarios/windows/vscode/README.md
@@ -1,0 +1,34 @@
+# VS Code Build Workload
+
+Compiles [Visual Studio Code](https://github.com/microsoft/vscode) (tag `1.106.2`) from source
+via `npm run compile` (TypeScript → `out/`). It reports compile time — a large TypeScript /
+Node.js build benchmark.
+
+## What HOBL sets up (from `vscode_resources/vscode_prep.ps1`)
+
+- Visual Studio 2022 C++ build tools (for native modules)
+- Node.js 22.20.0 (winget), Git, Python 3.12.10 (pyenv, required by node-gyp)
+- Clones `microsoft/vscode` @ `1.106.2` to `<drive>\vscode`; runs `npm install` during prep
+
+## Run it standalone (Windows)
+
+```powershell
+winget install --id Git.Git --source winget
+winget install --id OpenJS.NodeJS.22 --source winget --version 22.20.0 --architecture x64  # arm64 on ARM64
+pyenv install 3.12.10; pyenv local 3.12.10
+# + Visual Studio 2022 C++ build tools (needed by node-gyp)
+
+git clone https://github.com/microsoft/vscode.git
+cd vscode
+git checkout 1.106.2
+npm install
+
+# Timed workload
+npm run compile
+```
+
+## Notes
+
+- Requires PowerShell 7+. Only compile time is measured (no test phase).
+- HOBL preserves `node_modules/` between runs and cleans `out/` and `.build/` each loop.
+- Default: 1 loop. ARM64 uses Visual Studio Community (Build Tools is x64-only).

--- a/scenarios/windows/vscode/vscode_resources/vscode_prep.ps1
+++ b/scenarios/windows/vscode/vscode_resources/vscode_prep.ps1
@@ -160,8 +160,20 @@ if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
 # -------------------------------------------------------------------
 # Install Git
 # -------------------------------------------------------------------
+# --- Remove the msstore source before any winget install so a broken pinned
+# certificate on that source cannot fail the command (winget 0x8a15005e /
+# -1978335138) behind an SSL-inspecting proxy. All needed packages are on 'winget'. ---
+try {
+    if ((winget source list 2>$null) -match "msstore") {
+        "Removing msstore winget source to avoid pinned-certificate failures (0x8a15005e)" | log
+        winget source remove msstore 2>&1 | log
+    }
+} catch {
+    "Could not remove msstore source (continuing): $($_.Exception.Message)" | log
+}
+
 "-- Installing Git" | log
-winget install --id Git.Git --accept-source-agreements --accept-package-agreements
+winget install --id Git.Git --source winget --accept-source-agreements --accept-package-agreements
 checkWinget($lastexitcode)
 $Env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
 
@@ -174,9 +186,9 @@ check($lastexitcode)
 # -------------------------------------------------------------------
 "-- Installing Node.js 22.20.0 ($logSuffix)" | log
 if ($isARM64) {
-    winget install --id OpenJS.NodeJS.22 --version 22.20.0 --architecture arm64 --accept-source-agreements --accept-package-agreements
+    winget install --id OpenJS.NodeJS.22 --version 22.20.0 --architecture arm64 --source winget --accept-source-agreements --accept-package-agreements
 } else {
-    winget install --id OpenJS.NodeJS.22 --version 22.20.0 --architecture x64 --accept-source-agreements --accept-package-agreements
+    winget install --id OpenJS.NodeJS.22 --version 22.20.0 --architecture x64 --source winget --accept-source-agreements --accept-package-agreements
 }
 checkWinget($lastexitcode)
 $Env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")


### PR DESCRIPTION
## Summary
Two related changes for the Windows scenarios:
1. **Fix** all `winget install` calls that fail behind an SSL-inspecting corporate proxy.
2. **Add** a README to each of the 11 affected workload folders.

## Problem
Behind an SSL-inspecting proxy, winget's `msstore` source fails pinned-certificate
validation:

```
0x8a15005e : The server certificate did not match any of the expected values.
Failed when searching source: msstore

winget exits `-1978335138` (= `0x8A15005E`, `APPINSTALLER_CLI_ERROR_SOURCE_DATA_INTEGRITY_FAILURE`).
Because the preps call `winget install --id <pkg>` with no `--source`, winget queries **all**
sources (including `msstore`) and the whole command aborts. This took down 9 workloads on the
DUT and cascaded into downstream symptoms (e.g. spring_petclinic "Could not find Java 25",
pytorch "Rust installation failed").
```

## Fix
Every package we need is on the community `winget` source, so in each prep:
- Remove the `msstore` source up front (best-effort, wrapped in try/catch, reversible on the
  DUT with `winget source reset --force`).
- Pin every `winget install` to `--source winget`.

Affected preps (22 install sites): fast_api, foundrylocal, llvm, mlperf, net_aspire, ollama,
opencv_build, pytorch_inf, spring_petclinic, vscode, OpenCV.

## Docs
Adds `README.md` to each of the 11 workload folders (the 10 above + nodejs) describing what
the workload does/measures, what HOBL installs (tools + pinned repo/tag), and copy-pasteable
steps to run it standalone on a local DUT outside the framework.

## Testing / validation
- All 10 prep scripts parse cleanly (`[System.Management.Automation.Language.Parser]::ParseFile`).
- Verified zero remaining `winget install` lines without `--source winget`.
- README run steps validated against the actual prep/run scripts (clone URLs, pinned tags,
  and run commands).

## Notes
- No functional change to what gets installed — only the source is pinned and msstore removed.
- `--source winget` is a no-op on machines that aren't behind an inspecting proxy, so this is
  safe on any DUT.

