### PR TITLE
Update VS Code workloads to 1.132.0

### DIFF
--- a/scenarios/macos/mac_vscode/mac_vscode.py
+++ b/scenarios/macos/mac_vscode/mac_vscode.py
@@ -14,7 +14,7 @@ import time
 class MacVscode(scenarios.app_scenario.Scenario):
 
     module = __module__.split('.')[-1]
-    prep_version = "16"
+    prep_version = "17"
     resources = module + "_resources"
 
 

--- a/scenarios/macos/mac_vscode/mac_vscode_resources/mac_vscode_prep.sh
+++ b/scenarios/macos/mac_vscode/mac_vscode_resources/mac_vscode_prep.sh
@@ -95,18 +95,35 @@ if [ ! -x /opt/homebrew/bin/brew ]; then
 fi
 eval "$(/opt/homebrew/bin/brew shellenv)"
 
-# 3. Install Node.js 22
+# 3. Install Node.js 24.18.0
 log "-- Checking Node.js installation"
-if command -v node >/dev/null 2>&1 && node --version | grep -q "^v22"; then
-    log "✓ Node.js 22 already installed: $(node --version)"
+NODE_VERSION="24.18.0"
+NODE_PACKAGE="node-v${NODE_VERSION}.pkg"
+NODE_PACKAGE_URL="https://nodejs.org/dist/v${NODE_VERSION}/${NODE_PACKAGE}"
+NODE_PACKAGE_SHA256="e5a6701100066156d69da48878e4b95986733b0688e0b83afbe1093778e3fffd"
+NODE_PACKAGE_PATH="${TMPDIR:-/tmp}/${NODE_PACKAGE}"
+
+if command -v node >/dev/null 2>&1 && [ "$(node --version)" = "v${NODE_VERSION}" ]; then
+    log "✓ Node.js ${NODE_VERSION} already installed: $(node --version)"
 else
-    log "-- Installing Node.js 22..."
-    brew install node@22
-    check_status "Node.js 22 installation"
-    brew link node@22 --force --overwrite
-    check_status "Node.js 22 linking"
+    log "-- Installing Node.js ${NODE_VERSION}..."
+    brew list --formula | grep -E '^node(@.*)?$' | while read -r formula; do
+        brew unlink "$formula" >/dev/null 2>&1 || true
+    done
+    curl -fL "$NODE_PACKAGE_URL" -o "$NODE_PACKAGE_PATH"
+    check_status "Node.js ${NODE_VERSION} download"
+    echo "${NODE_PACKAGE_SHA256}  ${NODE_PACKAGE_PATH}" | shasum -a 256 -c -
+    check_status "Node.js ${NODE_VERSION} checksum verification"
+    sudo -A installer -pkg "$NODE_PACKAGE_PATH" -target /
+    check_status "Node.js ${NODE_VERSION} installation"
+    rm -f "$NODE_PACKAGE_PATH"
+    hash -r
 fi
 check_command "node" || exit 1
+if [ "$(node --version)" != "v${NODE_VERSION}" ]; then
+    log " ERROR - Node.js version is $(node --version), expected v${NODE_VERSION}"
+    exit 1
+fi
 log "-- Node.js version: $(node --version)"
 
 # 4. Install readline and xz (needed for pyenv Python builds)
@@ -169,9 +186,9 @@ cd "$VSCODE_DIR" || { log " ERROR - Failed to change to $VSCODE_DIR"; exit 1; }
 log "✓ Current directory: $(pwd)"
 
 # Checkout specific version
-log "-- Checking out VS Code version 1.106.2"
-git checkout 1.106.2
-check_status "VS Code checkout v1.106.2"
+log "-- Checking out VS Code version 1.132.0"
+git checkout 1.132.0
+check_status "VS Code checkout v1.132.0"
 
 # 7. Install npm dependencies
 log "-- Installing npm dependencies (this may take 10-20 minutes)..."
@@ -191,8 +208,8 @@ log "✓ phase-1 npm install completed"
 # Apply a checked-in patch (durable and auditable) instead of ad-hoc string
 # replacement in the script. This keeps the workaround deterministic for the
 # pinned VS Code tag.
-# TODO: Revisit/remove this patch when we move off VS Code 1.106.2 or when
-# upstream @vscode/spdlog/fmt builds cleanly on Darwin 25+ with Node 22.
+# The fast path below skips this compatibility patch when upstream
+# @vscode/spdlog/fmt already builds cleanly on Darwin 25+.
 PATCH_FILE="$BIN_DIR/mac_vscode_resources/spdlog_fmt_darwin25.patch"
 if [ ! -f "$PATCH_FILE" ]; then
     log " ERROR - Required patch file not found: $PATCH_FILE"

--- a/scenarios/windows/vscode/README.md
+++ b/scenarios/windows/vscode/README.md
@@ -1,26 +1,26 @@
 # VS Code Build Workload
 
-Compiles [Visual Studio Code](https://github.com/microsoft/vscode) (tag `1.106.2`) from source
+Compiles [Visual Studio Code](https://github.com/microsoft/vscode) (tag `1.132.0`) from source
 via `npm run compile` (TypeScript → `out/`). It reports compile time — a large TypeScript /
 Node.js build benchmark.
 
 ## What HOBL sets up (from `vscode_resources/vscode_prep.ps1`)
 
 - Visual Studio 2022 C++ build tools (for native modules)
-- Node.js 22.20.0 (winget), Git, Python 3.12.10 (pyenv, required by node-gyp)
-- Clones `microsoft/vscode` @ `1.106.2` to `<drive>\vscode`; runs `npm install` during prep
+- Node.js 24.18.0 (winget), Git, Python 3.12.10 (pyenv, required by node-gyp)
+- Clones `microsoft/vscode` @ `1.132.0` to `<drive>\vscode`; runs `npm install` during prep
 
 ## Run it standalone (Windows)
 
 ```powershell
 winget install --id Git.Git --source winget
-winget install --id OpenJS.NodeJS.22 --source winget --version 22.20.0 --architecture x64  # arm64 on ARM64
+winget install --id OpenJS.NodeJS.LTS --source winget --version 24.18.0 --architecture x64  # arm64 on ARM64
 pyenv install 3.12.10; pyenv local 3.12.10
 # + Visual Studio 2022 C++ build tools (needed by node-gyp)
 
 git clone https://github.com/microsoft/vscode.git
 cd vscode
-git checkout 1.106.2
+git checkout 1.132.0
 npm install
 
 # Timed workload

--- a/scenarios/windows/vscode/vscode.py
+++ b/scenarios/windows/vscode/vscode.py
@@ -14,7 +14,7 @@ import time
 class Vscode(scenarios.app_scenario.Scenario):
 
     module = __module__.split('.')[-1]
-    prep_version = "9"
+    prep_version = "10"
     resources = module + "_resources"
 
 

--- a/scenarios/windows/vscode/vscode_resources/vscode_prep.ps1
+++ b/scenarios/windows/vscode/vscode_resources/vscode_prep.ps1
@@ -182,20 +182,25 @@ git --version 2>&1 | log
 check($lastexitcode)
 
 # -------------------------------------------------------------------
-# Install Node.js 22.20.0
+# Install Node.js 24.18.0
 # -------------------------------------------------------------------
-"-- Installing Node.js 22.20.0 ($logSuffix)" | log
+"-- Installing Node.js 24.18.0 ($logSuffix)" | log
 if ($isARM64) {
-    winget install --id OpenJS.NodeJS.22 --version 22.20.0 --architecture arm64 --source winget --accept-source-agreements --accept-package-agreements
+    winget install --id OpenJS.NodeJS.LTS --version 24.18.0 --architecture arm64 --source winget --accept-source-agreements --accept-package-agreements --force
 } else {
-    winget install --id OpenJS.NodeJS.22 --version 22.20.0 --architecture x64 --source winget --accept-source-agreements --accept-package-agreements
+    winget install --id OpenJS.NodeJS.LTS --version 24.18.0 --architecture x64 --source winget --accept-source-agreements --accept-package-agreements --force
 }
 checkWinget($lastexitcode)
 $Env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
 
 "-- Verifying Node.js installation" | log
-node --version 2>&1 | log
+$installedNodeVersion = (node --version 2>&1).Trim()
+$installedNodeVersion | log
 check($lastexitcode)
+if ($installedNodeVersion -ne "v24.18.0") {
+    " ERROR - Node.js version is $installedNodeVersion, expected v24.18.0" | log
+    Exit 1
+}
 npm --version 2>&1 | log
 
 # -------------------------------------------------------------------
@@ -389,9 +394,9 @@ if (Test-Path $vscodePath) {
 git clone https://github.com/microsoft/vscode.git
 checkGitClone $lastexitcode "$vscodePath"
 
-"-- Checking out VS Code version 1.106.2" | log
+"-- Checking out VS Code version 1.132.0" | log
 Set-Location $vscodePath
-git checkout 1.106.2
+git checkout 1.132.0
 check($lastexitcode)
 
 # -------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- update the Windows `vscode` and macOS `mac_vscode` workloads to build VS Code 1.132.0
- pin Node.js 24.18.0 on both platforms
- bump both prep versions so previously prepared DUTs receive the new source and runtime
- keep the measured `npm run compile` commands, timing, cleanup, and metrics unchanged

## Runtime versions

VS Code 1.132.0 pins the following runtime components:

- Electron 42.7.1
- Node.js 24.18.0
- Chromium 148.0.7778.280

Windows installs the exact Node version from the `OpenJS.NodeJS.LTS` winget package for x64 or ARM64. macOS installs the official Node 24.18.0 package after validating its published SHA-256 checksum, avoiding Homebrew's moving `node@24` version.

## Benchmark impact

The HOBL run scripts continue to invoke `npm run compile` without modification. In VS Code 1.132.0, upstream defines that command to run `compile-client` and `compile-copilot` concurrently. This intentionally updates the measured workload to the current VS Code build and requires re-baselining rather than comparison with VS Code 1.106.2 results.

## Validation

- PowerShell parser check for `vscode_prep.ps1`
- Bash syntax check for `mac_vscode_prep.sh`
- Python compile checks for both scenario modules
- verified VS Code tag `1.132.0` exists upstream
- verified exact Node 24.18.0 x64, Windows ARM64, and macOS packages are published
- verified required new pins are present and old VS Code 1.106.2 / Node 22 pins are absent
- `git diff --check`
- confirmed the measured Windows and macOS run scripts are unchanged

Full end-to-end prep and compile validation for VS Code 1.132.0 still requires Windows and macOS DUT runs.