### PR TITLE
Fix Outlook Insert-Picture attach dropping leading path characters

### DIFF
--- a/scenarios/windows/_library/productivity/prod_outlook_new_run/prod_outlook_new_run.json
+++ b/scenarios/windows/_library/productivity/prod_outlook_new_run/prod_outlook_new_run.json
@@ -124,7 +124,7 @@
         "id": "UPVYR4",
         "text": "c:\\abl_docs\\Manarola2.png\ue007",
         "type": "Type",
-        "typing_delay": "[typing_delay]"
+        "typing_delay": "1000"
     },
     {
         "children": [],
@@ -288,7 +288,7 @@
         "id": "UPWXL9",
         "text": "c:\\abl_docs\\asample.pptx\ue007",
         "type": "Type",
-        "typing_delay": "[typing_delay]"
+        "typing_delay": "1000"
     },
     {
         "children": [],

--- a/scenarios/windows/_library/productivity/prod_outlook_run/prod_outlook_run.json
+++ b/scenarios/windows/_library/productivity/prod_outlook_run/prod_outlook_run.json
@@ -208,7 +208,7 @@
         "id": "UPVYR4",
         "text": "c:\\abl_docs\\Manarola2.png\ue007",
         "type": "Type",
-        "typing_delay": "[typing_delay]"
+        "typing_delay": "1000"
     },
     {
         "children": [],
@@ -278,7 +278,7 @@
             "image_VVXCYF.png"
         ],
         "id": "VVXCYF",
-        "match_threshold": "",
+        "match_threshold": "0.65",
         "primary": true,
         "type": "Click",
         "x": "0.500",
@@ -375,7 +375,7 @@
         "id": "UPWXL9",
         "text": "c:\\abl_docs\\asample.pptx\ue007",
         "type": "Type",
-        "typing_delay": "[typing_delay]"
+        "typing_delay": "1000"
     },
     {
         "children": [],


### PR DESCRIPTION
The productivity Outlook workflow types the full picture path into the Insert Picture "File name" field at the global typing_delay (200ms). At 200ms the Office file dialog (autocomplete + focus warm-up after the Alt+N,P that opens it) drops the leading path characters, so c:\abl_docs\Manarola2.png becomes _docs\Manarola2.png -> "Path does not exist", aborting at the following Discard step.

The three Office file-open dialogs (prod_excel/word/powerpoint_open) type filenames into the same dialog class and reliably use typing_delay=1000; apply the same to the two attach Types (UPVYR4, UPWXL9). Also set the Discard button (VVXCYF) match_threshold to 0.65 (it renders ~0.69-0.72 at 200% DPI, just under the 0.70 default).

Validated: productivity passed 5/6 across an 18-scenario overnight run after the change (previously failed every attempt at this step).