### PR TITLE
Scenario Maker Improvements

### DIFF
--- a/ScenarioMaker/actions.py
+++ b/ScenarioMaker/actions.py
@@ -6,7 +6,8 @@ Manages the list of actions.
 """
 
 from PyQt6 import QtCore, QtGui, QtWidgets
-from PyQt6.QtCore import Qt
+from PyQt6.QtCore import Qt, QUrl
+from PyQt6.QtGui import QDesktopServices
 from PyQt6.QtWidgets import QApplication, QDialog, QCheckBox, QLineEdit, QTextEdit, QVBoxLayout, QHBoxLayout, QFormLayout, QPushButton, QInputDialog, QLabel, QDialogButtonBox, QGroupBox, QComboBox
 from settings import SettingsData
 import os
@@ -575,8 +576,12 @@ class ActionDialog(QDialog):
                 h_layout = QHBoxLayout()
                 edit_button = QPushButton("Edit")
                 edit_button.clicked.connect(self.editCode)
+                open_external_button = QPushButton("Open Externally")
+                open_external_button.setToolTip("Open the code file in the OS default editor (e.g. VS Code).")
+                open_external_button.clicked.connect(self.openCodeExternally)
                 h_layout.addWidget(self.fileNameEdit)
                 h_layout.addWidget(edit_button)
+                h_layout.addWidget(open_external_button)
                 layout.addRow(QLabel("File Name"), h_layout)
             else:
                 h_layout_fn = QHBoxLayout()
@@ -664,6 +669,19 @@ class ActionDialog(QDialog):
         file_path = os.path.join(self.working_dir, self.file_name)
         self.editor = CodeEditorWindow(None, file_path)
         self.editor.show()
+        self.save()
+
+    def openCodeExternally(self):
+        file_path = os.path.join(self.working_dir, self.file_name)
+        # Create the file with the template contents if it doesn't exist yet, so the
+        # external editor has something to open.
+
+        if not QDesktopServices.openUrl(QUrl.fromLocalFile(file_path)):
+            QtWidgets.QMessageBox.warning(
+                self,
+                "Open Externally",
+                f"Could not open the file in an external editor:\n{file_path}"
+            )
         self.save()
     
     def addImageCheck(self):

--- a/ScenarioMaker/main_window.py
+++ b/ScenarioMaker/main_window.py
@@ -42,6 +42,7 @@ class MainWindow(QtWidgets.QMainWindow, main_form):
         central_layout.addWidget(self.tab_widget)
         self.tab_widget.setTabsClosable(True)
         self.tab_widget.currentChanged.connect(self.update_title)
+        self.tab_widget.currentChanged.connect(self.update_dpi_controls)
         # tab_count = self.tab_widget.count()
         # tab_title = "Untitled-"+str(tab_count)
         # self.tab_widget.addTab(Tab(app, settings_data, self, tab_count), tab_title)
@@ -198,6 +199,28 @@ class MainWindow(QtWidgets.QMainWindow, main_form):
         self.ui.okButton.setStyleSheet(stylesheet)
         self.ui.okButton.clicked.connect(self.ok_pressed)
         self.ui.okButton.hide()
+
+        # DPI override controls docked to the tab bar's top-right corner so they sit
+        # under the OK/Cancel buttons without crowding them.
+        self.dpiLabel = QtWidgets.QLabel("DPI:")
+        self.dpiEdit = QtWidgets.QLineEdit("")
+        self.dpiEdit.setFixedWidth(30)
+        self.dpiEdit.setValidator(QtGui.QIntValidator(1, 9999, self))
+        self.dpiEdit.setEnabled(True)
+        # self.dpiCheckbox = QtWidgets.QCheckBox("Override")
+        # self.dpiCheckbox.setChecked(False)
+        # self.dpiCheckbox.toggled.connect(self.dpiEdit.setEnabled)
+        self.dpiCornerWidget = QtWidgets.QWidget()
+        dpi_corner_layout = QtWidgets.QHBoxLayout(self.dpiCornerWidget)
+        dpi_corner_layout.setContentsMargins(0, 0, 6, 0)
+        dpi_corner_layout.setSpacing(4)
+        dpi_corner_layout.addWidget(self.dpiLabel)
+        dpi_corner_layout.addWidget(self.dpiEdit)
+        # dpi_corner_layout.addWidget(self.dpiCheckbox)
+        self.tab_widget.setCornerWidget(self.dpiCornerWidget, Qt.Corner.TopRightCorner)
+        self.dpiLabel.hide()
+        self.dpiEdit.hide()
+        # self.dpiCheckbox.hide()
 
         self.connection_manager.connection_available_signal.connect(self.connection_available)
         self.connection_manager.connection_attempt_signal.connect(self.connection_attempt)
@@ -677,6 +700,23 @@ class MainWindow(QtWidgets.QMainWindow, main_form):
         if not w:
             return
         w.open_image()
+
+    def show_dpi_controls(self):
+        self.dpiLabel.show()
+        self.dpiEdit.show()
+        # self.dpiCheckbox.show()
+
+    def hide_dpi_controls(self):
+        self.dpiLabel.hide()
+        self.dpiEdit.hide()
+        # self.dpiCheckbox.hide()
+
+    def update_dpi_controls(self):
+        w = self.tab_widget.currentWidget()
+        if w and getattr(w, "capture_mode", None) == "image":
+            self.show_dpi_controls()
+        else:
+            self.hide_dpi_controls()
 
     def remote_connect(self):
         w = self.tab_widget.currentWidget()

--- a/ScenarioMaker/main_window.py
+++ b/ScenarioMaker/main_window.py
@@ -200,27 +200,22 @@ class MainWindow(QtWidgets.QMainWindow, main_form):
         self.ui.okButton.clicked.connect(self.ok_pressed)
         self.ui.okButton.hide()
 
-        # DPI override controls docked to the tab bar's top-right corner so they sit
+        # DPI controls docked to the tab bar's top-right corner so they sit
         # under the OK/Cancel buttons without crowding them.
         self.dpiLabel = QtWidgets.QLabel("DPI:")
         self.dpiEdit = QtWidgets.QLineEdit("")
         self.dpiEdit.setFixedWidth(30)
         self.dpiEdit.setValidator(QtGui.QIntValidator(1, 9999, self))
         self.dpiEdit.setEnabled(True)
-        # self.dpiCheckbox = QtWidgets.QCheckBox("Override")
-        # self.dpiCheckbox.setChecked(False)
-        # self.dpiCheckbox.toggled.connect(self.dpiEdit.setEnabled)
         self.dpiCornerWidget = QtWidgets.QWidget()
         dpi_corner_layout = QtWidgets.QHBoxLayout(self.dpiCornerWidget)
         dpi_corner_layout.setContentsMargins(0, 0, 6, 0)
         dpi_corner_layout.setSpacing(4)
         dpi_corner_layout.addWidget(self.dpiLabel)
         dpi_corner_layout.addWidget(self.dpiEdit)
-        # dpi_corner_layout.addWidget(self.dpiCheckbox)
         self.tab_widget.setCornerWidget(self.dpiCornerWidget, Qt.Corner.TopRightCorner)
         self.dpiLabel.hide()
         self.dpiEdit.hide()
-        # self.dpiCheckbox.hide()
 
         self.connection_manager.connection_available_signal.connect(self.connection_available)
         self.connection_manager.connection_attempt_signal.connect(self.connection_attempt)
@@ -704,12 +699,10 @@ class MainWindow(QtWidgets.QMainWindow, main_form):
     def show_dpi_controls(self):
         self.dpiLabel.show()
         self.dpiEdit.show()
-        # self.dpiCheckbox.show()
 
     def hide_dpi_controls(self):
         self.dpiLabel.hide()
         self.dpiEdit.hide()
-        # self.dpiCheckbox.hide()
 
     def update_dpi_controls(self):
         w = self.tab_widget.currentWidget()

--- a/ScenarioMaker/tab.py
+++ b/ScenarioMaker/tab.py
@@ -106,8 +106,6 @@ class Tab(QtWidgets.QWidget):
         self.region_h = 0
         self.action_type = ""
         self.pending_dialog = None
-        # DPI (x, y) tuple read from the currently opened image, or None if unknown / not in image mode.
-        self.image_dpi = None
         self.hostPixelRatio = self.screen().devicePixelRatio()
 
         # Connect action list view
@@ -1127,23 +1125,9 @@ class Tab(QtWidgets.QWidget):
         if not os.path.exists(self.working_dir):
             os.makedirs(self.working_dir)
 
-        # DPI precedence for image mode: user override > embedded image DPI > (fallback TBD).
-        dpi = None
         if self.capture_mode == "image":
-            if self.main_win.dpiCheckbox.isChecked():
-                try:
-                    override = int(self.main_win.dpiEdit.text())
-                    dpi = (override, override)
-                    print(f"Saving template with override dpi {override}")
-                except ValueError:
-                    print(f"Invalid DPI override '{self.main_win.dpiEdit.text()}'; saving without DPI metadata.")
-            elif self.image_dpi is not None:
-                dpi = self.image_dpi
-                print(f"Saving template with source image dpi {self.image_dpi}")
-            else:
-                dut_dpi = int(96 * self.main_win.dutPixelRatio)
-                dpi = (dut_dpi, dut_dpi)
-                print(f"Didn't detect any DPI using dut dpi {dut_dpi} as a fallback.")
+            dpi_value = int(self.main_win.dpiEdit.text())
+            dpi = (dpi_value, dpi_value)
         else:
             dut_dpi = int(96 * self.main_win.dutPixelRatio)
             dpi = (dut_dpi, dut_dpi)
@@ -1344,7 +1328,7 @@ class Tab(QtWidgets.QWidget):
         if not image_dpi:
             prompt = (
                 f"No DPI metadata found in image:\n{os.path.basename(image_path)}\n\n"
-                "Enter a DPI value (72-300).\n\n"
+                "Enter a DPI value (96-192).\n\n"
                 "This should match the Windows display scaling of the DUT\n"
                 "that produced the image:\n"
                 "    96  = 100%\n"
@@ -1364,18 +1348,17 @@ class Tab(QtWidgets.QWidget):
                     dpi_value = int(text)
                 except ValueError:
                     dpi_value = None
-                if dpi_value is not None and 72 <= dpi_value <= 300:
+                if dpi_value is not None and 96 <= dpi_value <= 192:
                     break
             image_dpi = (dpi_value, dpi_value)
 
         self.capture_mode = "image"
-        self.image_dpi = image_dpi
         img = QtGui.QPixmap(image_path).toImage()
         img.setDevicePixelRatio(self.screen().devicePixelRatio())
         self.labelImage.setImage(img)
         self.last_capture_pil = Image.fromqimage(img)
-        print(f"Opened image DPI: {self.image_dpi}")
-        self.main_win.dpiEdit.setText(str(round(self.image_dpi[0])))
+        print(f"Opened image DPI: {image_dpi}")
+        self.main_win.dpiEdit.setText(str(round(image_dpi[0])))
         self.main_win.update_dpi_controls()
 
     def remote_connect(self):

--- a/ScenarioMaker/tab.py
+++ b/ScenarioMaker/tab.py
@@ -106,6 +106,8 @@ class Tab(QtWidgets.QWidget):
         self.region_h = 0
         self.action_type = ""
         self.pending_dialog = None
+        # DPI (x, y) tuple read from the currently opened image, or None if unknown / not in image mode.
+        self.image_dpi = None
         self.hostPixelRatio = self.screen().devicePixelRatio()
 
         # Connect action list view
@@ -1124,7 +1126,28 @@ class Tab(QtWidgets.QWidget):
         filepath = os.path.join(self.working_dir, name)
         if not os.path.exists(self.working_dir):
             os.makedirs(self.working_dir)
-        dut_dpi = int(96 * self.main_win.dutPixelRatio)
+
+        # DPI precedence for image mode: user override > embedded image DPI > (fallback TBD).
+        dpi = None
+        if self.capture_mode == "image":
+            if self.main_win.dpiCheckbox.isChecked():
+                try:
+                    override = int(self.main_win.dpiEdit.text())
+                    dpi = (override, override)
+                    print(f"Saving template with override dpi {override}")
+                except ValueError:
+                    print(f"Invalid DPI override '{self.main_win.dpiEdit.text()}'; saving without DPI metadata.")
+            elif self.image_dpi is not None:
+                dpi = self.image_dpi
+                print(f"Saving template with source image dpi {self.image_dpi}")
+            else:
+                dut_dpi = int(96 * self.main_win.dutPixelRatio)
+                dpi = (dut_dpi, dut_dpi)
+                print(f"Didn't detect any DPI using dut dpi {dut_dpi} as a fallback.")
+        else:
+            dut_dpi = int(96 * self.main_win.dutPixelRatio)
+            dpi = (dut_dpi, dut_dpi)
+            print(f"Saving template with dpi {dut_dpi}")
 
         if thumbnail:
             max_width = 500
@@ -1135,8 +1158,8 @@ class Tab(QtWidgets.QWidget):
             if r > 1.0:
                 r = 1.0
             image = image.resize((int(image.width*r), int(image.height*r)))
-        print(f"Saving template with dpi {dut_dpi}")
-        image.save(filepath, dpi=(dut_dpi, dut_dpi))
+
+        image.save(filepath, dpi=dpi)
         return filepath
 
 
@@ -1309,16 +1332,55 @@ class Tab(QtWidgets.QWidget):
 
     def open_image(self):
         image_path, _ = QtWidgets.QFileDialog.getOpenFileName(self, 'Select image')
-        if image_path:
-            self.capture_mode = "image"
-            img = QtGui.QPixmap(image_path).toImage()
-            img.setDevicePixelRatio(self.screen().devicePixelRatio())
+        if not image_path:
+            return
+        # Read DPI from the file directly; Image.fromqimage() loses PNG dpi metadata.
+        try:
+            with Image.open(image_path) as pil_img:
+                image_dpi = pil_img.info.get('dpi')
+        except:
+            print(f"Failed to read DPI from {image_path}")
+            image_dpi = None
+        if not image_dpi:
+            prompt = (
+                f"No DPI metadata found in image:\n{os.path.basename(image_path)}\n\n"
+                "Enter a DPI value (72-300).\n\n"
+                "This should match the Windows display scaling of the DUT\n"
+                "that produced the image:\n"
+                "    96  = 100%\n"
+                "    120 = 125%\n"
+                "    144 = 150%\n"
+                "    168 = 175%\n"
+                "    192 = 200%"
+            )
+            # Loop until we get a valid integer in range; cancelling aborts the image load.
+            while True:
+                text, ok = QtWidgets.QInputDialog.getText(
+                    self, "Set DPI", prompt, QtWidgets.QLineEdit.EchoMode.Normal, ""
+                )
+                if not ok:
+                    return
+                try:
+                    dpi_value = int(text)
+                except ValueError:
+                    dpi_value = None
+                if dpi_value is not None and 72 <= dpi_value <= 300:
+                    break
+            image_dpi = (dpi_value, dpi_value)
 
-            self.labelImage.setImage(img)
-            self.last_capture_pil = Image.fromqimage(img)
+        self.capture_mode = "image"
+        self.image_dpi = image_dpi
+        img = QtGui.QPixmap(image_path).toImage()
+        img.setDevicePixelRatio(self.screen().devicePixelRatio())
+        self.labelImage.setImage(img)
+        self.last_capture_pil = Image.fromqimage(img)
+        print(f"Opened image DPI: {self.image_dpi}")
+        self.main_win.dpiEdit.setText(str(round(self.image_dpi[0])))
+        self.main_win.update_dpi_controls()
 
     def remote_connect(self):
         self.capture_mode = "remote"
+        self.main_win.update_dpi_controls()
 
     ###
     ### Action item list


### PR DESCRIPTION
Scenariomaker:
- Attempts to read DPI from image when opening an image, and if no DPI is present a popup will appear asking user to enter a DPI. Textbox near top right to allow users to change the value of DPI as well. 
- For Codeblocks added an option to open code block externally, for example like vscode, to edit.